### PR TITLE
Refactor start screen assets

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ゲーム画面</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="game-container">
+        <h1>ここからゲームが始まります</h1>
+        <p>コンテンツは今後追加予定です。</p>
+    </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,20 +1,21 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>コンサルタント経済シミュレーション</title>
-    <!-- スタイルシートを読み込みます -->
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ECON – Start</title>
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- 外部CSSを読み込み -->
+  <link rel="stylesheet" href="start.css" />
+  <!-- 外部JavaScriptを読み込み -->
+  <script defer src="start.js"></script>
 </head>
-<body>
-    <!-- 画面中央に配置するコンテナ -->
-    <div id="container">
-        <h1>ゲームスタート</h1>
-        <!-- スタートボタン -->
-        <button id="startButton">開始</button>
-    </div>
-    <!-- JavaScript を読み込みます -->
-    <script src="script.js"></script>
+<body class="h-screen w-screen flex items-center justify-center select-none">
+  <!-- 中央にタイトルを表示。クリック判定はbody全体 -->
+  <h1 class="text-6xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-pulse">
+    ECON
+  </h1>
 </body>
 </html>

--- a/public/start.css
+++ b/public/start.css
@@ -1,0 +1,13 @@
+/* スタート画面の背景パターンを設定 */
+body {
+    /* ドット風のストライプ背景 */
+    background-image: repeating-linear-gradient(
+        45deg,
+        #d9d9d9 0 15px,
+        #cfcfcf 15px 30px
+    );
+    /* ドットがくっきり見えるようにする */
+    image-rendering: pixelated;
+    margin: 0;
+    padding: 0;
+}

--- a/public/start.js
+++ b/public/start.js
@@ -1,0 +1,6 @@
+// ページ全体をクリックまたはタップしたとき game.html に移動する
+['click', 'touchstart'].forEach(function(ev) {
+    document.addEventListener(ev, function() {
+        window.location.href = 'game.html';
+    }, { once: true }); // 一度だけ実行
+});


### PR DESCRIPTION
## Summary
- refactor index.html to rely on external `start.css` and `start.js`
- move background style into `start.css`
- handle tap/click navigation in `start.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843ffdbb2d4832c97a5db4d4cf1a601