### PR TITLE
Apply flex layout to start screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 npm-debug.log*
+.setup_done

--- a/public/game.html
+++ b/public/game.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ゲーム画面</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="game-container">
+        <h1>ここからゲームが始まります</h1>
+        <p>コンテンツは今後追加予定です。</p>
+    </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,20 +1,28 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>コンサルタント経済シミュレーション</title>
-    <!-- スタイルシートを読み込みます -->
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ECON – Start</title>
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- 外部CSSを読み込み -->
+  <link rel="stylesheet" href="start.css" />
+  <!-- 外部JavaScriptを読み込み -->
+  <script defer src="start.js"></script>
 </head>
-<body>
-    <!-- 画面中央に配置するコンテナ -->
-    <div id="container">
-        <h1>ゲームスタート</h1>
-        <!-- スタートボタン -->
-        <button id="startButton">開始</button>
+  <body class="h-screen w-screen flex items-center justify-center select-none">
+    <!-- タイトルとボタンをまとめるラッパー -->
+    <div class="flex flex-col md:flex-row items-center gap-4">
+      <!-- ゲームタイトル -->
+      <h1 class="text-6xl font-extrabold tracking-wider drop-shadow-lg animate-pulse">
+        ECON
+      </h1>
+      <!-- スタートボタン -->
+      <button id="startButton" class="px-4 py-2 bg-blue-500 text-white rounded">
+        開始
+      </button>
     </div>
-    <!-- JavaScript を読み込みます -->
-    <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/public/start.css
+++ b/public/start.css
@@ -1,0 +1,25 @@
+/* スタート画面の背景パターンを設定 */
+body {
+    /* ドット風のストライプ背景 */
+    background-image: repeating-linear-gradient(
+        45deg,
+        #d9d9d9 0 15px,
+        #cfcfcf 15px 30px
+    );
+    /* ドットがくっきり見えるようにする */
+    image-rendering: pixelated;
+    margin: 0;
+    padding: 0;
+}
+
+/* タイトルの文字色を設定 */
+h1 {
+    color: #3b82f6; /* 青色 */
+}
+
+/* スタートボタンの簡単なデザイン */
+#startButton {
+    font-size: 1rem;
+    border: none;
+    border-radius: 0.25rem;
+}

--- a/public/start.js
+++ b/public/start.js
@@ -1,0 +1,12 @@
+// ボタンが押されたら game.html に移動する処理
+window.addEventListener('DOMContentLoaded', function() {
+    // ボタンの要素を取得
+    var startButton = document.getElementById('startButton');
+    // クリックとタップの両方に対応
+    ['click', 'touchstart'].forEach(function(ev) {
+        startButton.addEventListener(ev, function() {
+            // game.html へ遷移
+            window.location.href = 'game.html';
+        }, { once: true }); // 一度だけ実行
+    });
+});


### PR DESCRIPTION
## Summary
- make the start screen layout mobile friendly with flex
- move navigation logic to button events
- style the start button and title via CSS
- ignore setup marker file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ffdbb2d4832c97a5db4d4cf1a601