### PR TITLE
ゲーム画面のID名を修正

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -9,7 +9,7 @@ body {
 }
 
 
-#container {
+#game-container {
     padding-top: 40vh; /* 画面中央付近に配置 */
 }
 


### PR DESCRIPTION
## 変更内容
- `public/game_screen.css` の `#container` を `#game-container` に変更し、HTML と統一しました。
- CSS の指定により、ゲーム画面の内容は画面中央付近に表示されます。

## 動作確認
- `w3m` で `public/game_screen.html` を表示し、内容を確認しました。
- `npm test` を実行し、既存テストが成功することを確認しました。

## 使い方（簡易説明）
1. `public/start_screen.html` をブラウザで開きます。
2. 画面をクリックまたはタップするとゲーム画面へ遷移します。


------
https://chatgpt.com/codex/tasks/task_e_68451eac9554832caf36d523d8b9d177