### PR TITLE
スタート画面の背景とアニメーション調整

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -1,12 +1,9 @@
 /* スタート画面の背景パターンを設定 */
 body {
-    /* ドット風のストライプ背景 */
-    background-image: repeating-linear-gradient(
-        45deg,
-        #d9d9d9 0 15px,
-        #cfcfcf 15px 30px
-    );
-    /* ドットがくっきり見えるようにする */
+    /* 背景画像を設定 */
+    /* 画像は public/images/game_screen.webp を使用 */
+    background-image: url('./images/game_screen.webp');
+    /* ピクセルアートのような見た目を保つ */
     image-rendering: pixelated;
     margin: 0;
     padding: 0;

--- a/public/start_screen.html
+++ b/public/start_screen.html
@@ -14,7 +14,8 @@
 </head>
   <body class="h-screen w-screen flex items-center justify-center select-none">
     <!-- 中央にゲームタイトルのみ表示し、画面全体をタップで遷移 -->
-    <h1 class="text-6xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-pulse">
+    <!-- Tailwindのアニメーションを利用してロゴをバウンスさせる -->
+    <h1 class="text-5xl sm:text-6xl md:text-8xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-bounce">
       ECON
     </h1>
   </body>


### PR DESCRIPTION
## 概要
- スタート画面の背景を `game_screen.webp` に変更し、ピクセル風表示を維持
- タイトルに `animate-bounce` を追加し、サイズをレスポンシブ化

## 使い方
1. `public/start_screen.html` をブラウザで開く
2. 画面をタップするとゲーム画面に遷移

## テスト
- `npm install` を実行
- `npm test` が成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_68451e9778ac832ca5d47c0d623ba39d