### PR TITLE
Reactによるスタート画面実装

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,13 +9,17 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- 外部CSSを読み込み -->
   <link rel="stylesheet" href="start_screen.css" />
-  <!-- 外部JavaScriptを読み込み -->
-  <script defer src="start_screen.js"></script>
+  
+  <!-- React本体をCDNから読み込み -->
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <!-- ReactDOMもCDNから読み込み -->
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  
+  <!-- React版のスタート画面スクリプトを読み込み -->
+  <script defer src="start_screen_react.js"></script>
 </head>
-  <body class="h-screen w-screen flex items-center justify-center select-none">
-    <!-- 中央にゲームタイトルのみ表示し、画面全体をタップで遷移 -->
-    <h1 class="text-6xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-pulse">
-      ECON
-    </h1>
+  <body class="h-screen w-screen">
+    <!-- React コンポーネントをマウントするための要素 -->
+    <div id="root"></div>
   </body>
 </html>

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -1,0 +1,47 @@
+// Reactを使ったスタート画面のスクリプト
+// 画面のどこをクリックしても game_screen.html へ遷移します
+
+// ① Reactの機能を使うために変数に取り出します
+const { useEffect } = React;
+
+// ② スタート画面を表すコンポーネントを定義します
+function StartScreen() {
+  // コンポーネントが初めて表示されたときに実行したい処理を useEffect に書きます
+  useEffect(() => {
+    // body 全体にカーソルを指の形にするクラスを追加
+    document.body.classList.add('cursor-pointer');
+    // クリーンアップ関数でコンポーネントが消えたときに元に戻す
+    return () => {
+      document.body.classList.remove('cursor-pointer');
+    };
+  }, []); // 空配列なので最初の1回だけ実行されます
+
+  // 画面全体が押されたら遷移する処理
+  const handleClick = () => {
+    // ゲーム画面へ移動
+    window.location.href = 'game_screen.html';
+  };
+
+  // JSX で画面の見た目を記述します
+  return (
+    // divを画面いっぱいに広げ、中央にタイトルを表示します
+    React.createElement(
+      'div',
+      {
+        className: 'h-screen w-screen flex items-center justify-center select-none',
+        onClick: handleClick,
+      },
+      React.createElement(
+        'h1',
+        {
+          className:
+            'text-6xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-pulse',
+        },
+        'ECON'
+      )
+    )
+  );
+}
+
+// ③ ここで ReactDOM を使って画面に描画します
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(StartScreen));


### PR DESCRIPTION
## 変更点
- `public/index.html` に React の CDN を追加し、マウント用の `<div id="root">` を配置しました
- `start_screen_react.js` を新規追加し、React コンポーネント `StartScreen` を定義しました
- 画面全体のクリックで `game_screen.html` に遷移するよう実装しました
- 既存の `start_screen.js` はテスト用に残してあります

## 使い方
1. `npm install` で依存パッケージをインストール
2. `npm start` を実行し、ブラウザで `http://localhost:8080/index.html` を開きます
3. 表示された画面をクリックするとゲーム画面へ進みます

## テスト
`npm test` を実行し、既存テストが成功することを確認しました

------
https://chatgpt.com/codex/tasks/task_e_684621e13c00832c9c54fe6943f64e14