### PR TITLE
window.onload を DOMContentLoaded へ変更

### DIFF
--- a/public/start_screen.js
+++ b/public/start_screen.js
@@ -1,8 +1,9 @@
 // スタート画面の挙動をまとめたスクリプト
 // 画面全体のタップまたはボタン押下で game_screen.html へ遷移します
 
-// ページ読み込み後に実行される処理を設定
-window.onload = function() {
+// DOM の読み込みが完了したタイミングで処理を実行します
+// window.onload よりも早く動作するため、画面表示がスムーズになります
+document.addEventListener('DOMContentLoaded', function() {
     // startButton が存在する場合、クリック時にメッセージを表示して遷移
     var startButton = document.getElementById('startButton');
     if (startButton) {
@@ -18,4 +19,4 @@ window.onload = function() {
             window.location.href = 'game_screen.html';
         }, { once: true });
     });
-};
+});

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -7,11 +7,12 @@ describe('public/start_screen.js', () => {
     document.body.innerHTML = '<button id="startButton"></button>';
     // alertをモック
     global.alert = jest.fn();
-    // start_screen.jsを読み込み、window.onload を実行
+    // start_screen.js を読み込み、DOMContentLoaded を発火
     jest.isolateModules(() => {
       require('../public/start_screen.js');
     });
-    window.onload();
+    // DOMContentLoaded イベントを手動で発火させる
+    document.dispatchEvent(new Event('DOMContentLoaded'));
   });
 
   test('ボタンをクリックするとメッセージが表示される', () => {


### PR DESCRIPTION
## 変更点
- start_screen.js で `window.onload` の代わりに `DOMContentLoaded` を使用
- それに合わせてテストも `DOMContentLoaded` を発火する形に修正

## 使い方
1. `npm install` で依存関係を導入
2. `npm test` でテスト実行
3. `npm start` 後、ブラウザで `http://localhost:8080/index.html` を開き画面をタップするとゲーム画面へ移動します

------
https://chatgpt.com/codex/tasks/task_e_68466fef3560832c807413b57e59efca