### PR TITLE
背景画像の設定

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -1,13 +1,13 @@
-/* スタート画面の背景パターンを設定 */
+/* スタート画面の背景画像を設定 */
 body {
-    /* ドット風のストライプ背景 */
-    background-image: repeating-linear-gradient(
-        45deg,
-        #d9d9d9 0 15px,
-        #cfcfcf 15px 30px
-    );
-    /* ドットがくっきり見えるようにする */
-    image-rendering: pixelated;
+    /* game_screen.webp を背景に指定 */
+    background-image: url('images/game_screen.webp');
+    /* 画像を中央に表示し、はみ出さないよう全体を収める */
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    /* スクロールしても背景を固定する */
+    background-attachment: fixed;
     margin: 0;
     padding: 0;
 }


### PR DESCRIPTION
## 変更内容
- `index.html` で読み込む `start_screen.css` を更新し、スタート画面の背景に `game_screen.webp` を表示するよう変更
- 背景画像がスマホでも全体表示されるよう `background-size: contain` などを指定

## 使い方
`npm start` で `http://localhost:8080/index.html` を開くと、背景にゲーム画面の画像が表示されたスタート画面が確認できます。

## テスト結果
- `npm test` で既存テストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_6846ad132a3c832c833840f2751d2b9c