### PR TITLE
ヘッダーのデザイン調整

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -10,9 +10,15 @@
   <!-- ヘッダー: 収入と評価を表示 -->
   <header class="bg-gray-800 text-white flex justify-between items-center px-4 py-2">
     <button id="drawerBtn" class="text-2xl">☰</button>
-    <div class="flex gap-6 text-lg font-mono">
-      <span>💰 <span id="money">12,300</span></span>
-      <span>★ <span id="rating">4.5</span></span>
+    <div class="flex gap-2 text-lg font-mono">
+      <span class="flex items-center gap-1 p-1 rounded bg-green-100 text-green-600">
+        <span class="w-2 h-2 bg-current rounded"></span>
+        <span>💰 <span id="money">12,300</span></span>
+      </span>
+      <span class="flex items-center gap-1 p-1 rounded bg-yellow-100 text-yellow-600">
+        <span class="w-2 h-2 bg-current rounded"></span>
+        <span>★ <span id="rating">4.5</span></span>
+      </span>
     </div>
   </header>
 

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -94,10 +94,30 @@ function GameScreen() {
       React.createElement(
         'div',
         { className: 'mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm sm:text-lg font-mono text-center' },
-        React.createElement('div', { className: 'text-red-300 font-semibold' }, `CPI ${stats.cpi.toFixed(1)}`),
-        React.createElement('div', { className: 'text-blue-300 font-semibold' }, `失業率 ${stats.unemp.toFixed(1)}%`),
-        React.createElement('div', { className: 'text-green-300 font-semibold' }, `金利 ${stats.rate.toFixed(1)}%`),
-        React.createElement('div', { className: 'text-yellow-300 font-semibold' }, `GDP ${stats.gdp.toFixed(1)}%`)
+        React.createElement(
+          'div',
+          { className: 'flex items-center justify-center gap-1 p-1 rounded text-red-600 bg-red-100 font-semibold' },
+          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
+          `CPI ${stats.cpi.toFixed(1)}`
+        ),
+        React.createElement(
+          'div',
+          { className: 'flex items-center justify-center gap-1 p-1 rounded text-blue-600 bg-blue-100 font-semibold' },
+          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
+          `失業率 ${stats.unemp.toFixed(1)}%`
+        ),
+        React.createElement(
+          'div',
+          { className: 'flex items-center justify-center gap-1 p-1 rounded text-green-600 bg-green-100 font-semibold' },
+          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
+          `金利 ${stats.rate.toFixed(1)}%`
+        ),
+        React.createElement(
+          'div',
+          { className: 'flex items-center justify-center gap-1 p-1 rounded text-yellow-600 bg-yellow-100 font-semibold' },
+          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
+          `GDP ${stats.gdp.toFixed(1)}%`
+        )
       )
     ),
     // ドロワー


### PR DESCRIPTION
## 変更内容
- プレーン版 `game_screen.html` のヘッダー項目を色付きボックスで表示
- React 版 `game_screen_react.js` でも同様に各指標を色分けしてボックス化
- それぞれの要素に余白と角丸を追加し、文字色に合わせた小さなボックスを表示

## テスト結果
- `npm test` を実行し、既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_684779d80b58832c9f5bf1e05201b873