### PR TITLE
ヘッダーの経済指標リストを修正

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -36,7 +36,7 @@
     <div class="relative bg-white rounded shadow-lg w-11/12 max-w-md p-6 space-y-4 z-10">
       <button id="closeModal" class="absolute top-2 right-3 text-xl">×</button>
       <h2 class="text-xl font-bold mb-2">経済指標</h2>
-      <ul class="space-y-1 font-mono">
+      <ul class="space-y-1 font-mono list-none">
         <li>CPI: <span id="cpi">102.4</span></li>
         <li>失業率: <span id="unemp">4.2</span>%</li>
         <li>GDP成長率: <span id="gdp">1.8</span>%</li>


### PR DESCRIPTION
## 変更内容
- `public/game_screen.html` の経済指標を表示するリストに `list-none` クラスを追加し、箇条書き点を非表示にしました。

## 使い方
ゲーム画面を開き、左上のメニューから「📊 経済指標」を選択するとモーダルに各指標が表示されます。今回の変更で指標の前の黒丸が消え、シンプルに数値だけが表示されます。

------
https://chatgpt.com/codex/tasks/task_e_68478057d834832cbff86eb049ba66ad