### PR TITLE
ドロワー開閉をスムーズにする更新

### DIFF
--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -71,6 +71,14 @@ function GameScreen() {
   // ドロワーの開閉
   const toggleDrawer = () => setDrawerOpen(o => !o);
 
+  // ドロワーのclassを状態に応じて生成
+  const drawerClasses = [
+    'fixed top-0 right-0 h-full w-2/3 sm:w-64',
+    'bg-white shadow-lg z-10 overflow-y-auto',
+    'transform transition-transform duration-300',
+    drawerOpen ? 'translate-x-0' : 'translate-x-full'
+  ].join(' ');
+
   return React.createElement(
     'div',
     { className: 'bg-gray-100 select-none' },
@@ -121,28 +129,20 @@ function GameScreen() {
       )
     ),
     // ドロワー
-    drawerOpen
-      ? (() => {
-          return React.createElement(
-            'div',
-            {
-              id: 'drawer',
-              className:
-                'fixed top-0 right-0 h-full w-2/3 sm:w-64 bg-white shadow-lg z-10 overflow-y-auto',
-            },
-            React.createElement(
-              'ul',
-              { className: 'p-4 space-y-2 text-sm list-none' },
-              React.createElement('li', { className: 'flex justify-between' }, '為替', React.createElement('span', null, stats.fx.toFixed(1))),
-              React.createElement('li', { className: 'flex justify-between' }, '10年国債', React.createElement('span', null, `${stats.yield.toFixed(1)}%`)),
-              React.createElement('li', { className: 'flex justify-between' }, '消費者信頼感', React.createElement('span', null, stats.cci.toFixed(1))),
-              React.createElement('li', { className: 'flex justify-between' }, 'PMI', React.createElement('span', null, stats.pmi.toFixed(1))),
-              React.createElement('li', { className: 'flex justify-between' }, '財政赤字/GDP', React.createElement('span', null, `${stats.debtGDP.toFixed(1)}%`)),
-              React.createElement('li', { className: 'flex justify-between' }, '貿易収支', React.createElement('span', null, `${stats.trade.toFixed(0)}億円`))
-            )
-          );
-        })()
-      : null,
+    React.createElement(
+      'div',
+      { id: 'drawer', className: drawerClasses },
+      React.createElement(
+        'ul',
+        { className: 'p-4 space-y-2 text-sm list-none' },
+        React.createElement('li', { className: 'flex justify-between' }, '為替', React.createElement('span', null, stats.fx.toFixed(1))),
+        React.createElement('li', { className: 'flex justify-between' }, '10年国債', React.createElement('span', null, `${stats.yield.toFixed(1)}%`)),
+        React.createElement('li', { className: 'flex justify-between' }, '消費者信頼感', React.createElement('span', null, stats.cci.toFixed(1))),
+        React.createElement('li', { className: 'flex justify-between' }, 'PMI', React.createElement('span', null, stats.pmi.toFixed(1))),
+        React.createElement('li', { className: 'flex justify-between' }, '財政赤字/GDP', React.createElement('span', null, `${stats.debtGDP.toFixed(1)}%`)),
+        React.createElement('li', { className: 'flex justify-between' }, '貿易収支', React.createElement('span', null, `${stats.trade.toFixed(0)}億円`))
+      )
+    ),
     // トースト
     toast
       ? React.createElement(


### PR DESCRIPTION
## 変更点
- `drawerOpen` の状態に応じてクラスを生成する `drawerClasses` を追加
- ドロワー生成を `React.createElement('div', { id: 'drawer', className: drawerClasses }, ...)` に変更
- 常にドロワー要素をレンダリングし、CSS の `transform` で右から滑らかに開閉

## 使い方
1. `npm install` で依存パッケージをインストール
2. `npm start` を実行しブラウザで `http://localhost:8080/game_screen_react.html` を開く
3. 右上のメニューボタンを押すとドロワーが滑らかに開閉する

## テスト
- `npm test` でスクリプトテストを実行し、1件成功を確認


------
https://chatgpt.com/codex/tasks/task_e_684783a256f4832caaf3b8dadd406e40