### PR TITLE
ヘッダーのグラデーション化と指数パネルのスタイル変更

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -8,7 +8,7 @@
 <body class="h-screen overflow-hidden">
 
   <!-- ヘッダー: 収入と評価を表示 -->
-  <header class="bg-gray-800 text-white flex justify-between items-center px-4 py-2">
+  <header class="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900/90 text-white flex justify-between items-center px-4 py-2">
     <button id="drawerBtn" class="text-2xl">☰</button>
     <div class="flex gap-2 text-lg font-mono">
       <span class="flex items-center gap-1 p-1 rounded bg-green-100 text-green-600">

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -85,7 +85,10 @@ function GameScreen() {
     // ヘッダー（タイトルとメニュー）
     React.createElement(
       'header',
-      { className: 'bg-gray-800 text-white px-4 py-2' },
+      {
+        className:
+          'bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900/90 text-white px-4 py-2',
+      },
       React.createElement(
         'div',
         { className: 'flex justify-between items-center' },
@@ -95,30 +98,41 @@ function GameScreen() {
       // 主要4指数を大きめに表示
       React.createElement(
         'div',
-        { className: 'mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm sm:text-lg font-mono text-center' },
+        {
+          className:
+            'mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm sm:text-lg font-mono text-center',
+        },
         React.createElement(
           'div',
-          { className: 'flex items-center justify-center gap-1 p-1 rounded text-red-600 bg-red-100 font-semibold' },
-          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
-          `CPI ${stats.cpi.toFixed(1)}`
+          {
+            className:
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+          },
+          `CPI: ${stats.cpi.toFixed(1)}`
         ),
         React.createElement(
           'div',
-          { className: 'flex items-center justify-center gap-1 p-1 rounded text-blue-600 bg-blue-100 font-semibold' },
-          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
-          `失業率 ${stats.unemp.toFixed(1)}%`
+          {
+            className:
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+          },
+          `失業率: ${stats.unemp.toFixed(1)}%`
         ),
         React.createElement(
           'div',
-          { className: 'flex items-center justify-center gap-1 p-1 rounded text-green-600 bg-green-100 font-semibold' },
-          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
-          `金利 ${stats.rate.toFixed(1)}%`
+          {
+            className:
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+          },
+          `金利: ${stats.rate.toFixed(1)}%`
         ),
         React.createElement(
           'div',
-          { className: 'flex items-center justify-center gap-1 p-1 rounded text-yellow-600 bg-yellow-100 font-semibold' },
-          React.createElement('span', { className: 'w-2 h-2 bg-current rounded' }),
-          `GDP ${stats.gdp.toFixed(1)}%`
+          {
+            className:
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+          },
+          `GDP: ${stats.gdp.toFixed(1)}%`
         )
       )
     ),


### PR DESCRIPTION
## 変更内容
- React版ゲーム画面(`game_screen_react.js`)のヘッダーを黒系グラデーションに変更
- 各経済指数ボックスを半透明パネル風のデザインへ統一
- `game_screen.html` のヘッダーも同様のグラデーションに調整

## 簡単な使い方
- `public/index.html` をブラウザで開き、画面をタップするとゲームが始まります。
- React版ゲーム画面ではヘッダーの経済指標が新しい半透明パネルで表示されます。

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684787393f48832c88db0b7397902f15