### PR TITLE
ゲーム画面でフォント変更

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -3,7 +3,16 @@
 
 body {
   margin: 0;
-  font-family: sans-serif;
+  /* デフォルトはOrbitron */
+  font-family: 'Orbitron', sans-serif;
+}
+
+/* 小さめの文字には読みやすい日本語フォントを適用 */
+.text-sm,
+.text-base,
+.text-xs,
+.font-mono {
+  font-family: 'Noto Sans JP', sans-serif;
 }
 
 /* ドロワーの重なり順を明示 */

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -4,8 +4,12 @@
   <meta charset="UTF-8">
   <title>ECON – Game</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Googleフォントの読み込み -->
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
+  <!-- 追加スタイル -->
+  <link rel="stylesheet" href="game_screen.css">
 </head>
-<body class="h-screen overflow-hidden">
+<body class="h-screen overflow-hidden font-[Orbitron]">
 
   <!-- ヘッダー: 収入と評価を表示 -->
   <header class="bg-gray-800 text-white flex justify-between items-center px-4 py-2">

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -6,6 +6,8 @@
   <title>ECON – Screen (React)</title>
   <!-- TailwindCSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Googleフォントの読み込み -->
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
   <!-- React と ReactDOM を CDN から読み込み -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
@@ -14,7 +16,7 @@
   <!-- React版スクリプト読み込み -->
   <script defer src="game_screen_react.js"></script>
 </head>
-<body class="bg-gray-100 select-none">
+<body class="bg-gray-100 select-none font-[Orbitron]">
   <div id="root"></div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
Googleフォントの読み込みを追加し、ゲーム画面で表示サイズによってフォントが変わるようにCSSを調整しました。

## 変更点
- `game_screen.html` と `game_screen_react.html` に Orbitron と Noto Sans JP を読み込む `<link>` を追加
- `body` クラスに `font-[Orbitron]` を指定
- `game_screen.css` で小さめの文字(`text-sm` など)は Noto Sans JP を適用
- テストを実行し、既存テストが成功することを確認

## 動作確認
- `npm test` でテストがパスすることを確認しました


------
https://chatgpt.com/codex/tasks/task_e_684787e2b5f0832c927d576cf60ff88c