### PR TITLE
ゲーム画面のスクリプト外部化

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -49,24 +49,8 @@
       </ul>
     </div>
   </div>
-  <script>
-    // ドロワーやモーダルの要素を取得
-    const drawer   = document.getElementById('drawer');
-    const drawerBtn= document.getElementById('drawerBtn');
-    const statsBtn = document.getElementById('statsBtn');
-    const modal    = document.getElementById('statsModal');
-    const closeBtn = document.getElementById('closeModal');
-    const modalBg  = document.getElementById('modalBg');
-
-    // ドロワーボタンを押すと、ドロワーを開閉
-    drawerBtn.onclick = () => drawer.classList.toggle('-translate-x-full');
-    // 経済指標ボタンでモーダルを表示
-    statsBtn.onclick  = () => { modal.classList.remove('hidden'); };
-    // モーダルの "×" ボタンで非表示
-    closeBtn.onclick  = () => { modal.classList.add('hidden'); };
-    // 背景クリックでもモーダルを閉じる
-    modalBg.onclick   = () => { modal.classList.add('hidden'); };
-  </script>
+  <!-- ゲーム用スクリプトを読み込み -->
+  <script src="game_screen.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## 変更内容
- `public/game_screen.html` のインライン `<script>` を削除
- 末尾に `game_screen.js` を読み込むタグを追加

## 動作確認
- Puppeteer を用いて `game_screen.html` を読み込み、ドロワーボタンの動作を確認しました
- `npm test` を実行し既存テストが成功することを確認しました

## 使い方
ブラウザで `public/index.html` を開き、画面をタップするとゲームが始まります。ゲーム画面では画面左上のメニューボタンからサイドドロワーを開閉できます。

------
https://chatgpt.com/codex/tasks/task_e_68478afa11ac832ca82160f8d0d7f6d4