### PR TITLE
DOMContentLoaded で初期化

### DIFF
--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -1,7 +1,9 @@
 // ゲーム画面の操作をまとめたスクリプト
 // ドロワーとモーダルの開閉のみを担当します
 
-window.onload = function () {
+// DOMContentLoaded イベントは DOM の構築が終わったときに発火します
+// ページが準備できたら各要素を取得してイベントを設定します
+window.addEventListener('DOMContentLoaded', function () {
   // --- 要素の取得 ----------------------------------
   const drawer = document.getElementById('drawer');
   const drawerBtn = document.getElementById('drawerBtn');
@@ -38,4 +40,4 @@ window.onload = function () {
       modal.classList.add('hidden');
     });
   });
-};
+}, { capture: true });

--- a/public/start_screen.js
+++ b/public/start_screen.js
@@ -1,8 +1,10 @@
 // スタート画面の挙動をまとめたスクリプト
 // 画面全体のタップまたはボタン押下で game_screen.html へ遷移します
 
-// ページ読み込み後に実行される処理を設定
-window.onload = function() {
+// ページの読み込みが完了したタイミングで実行される処理を設定
+// DOMContentLoaded は HTML の解析が終わった直後に発火します
+// capture を true にするとキャプチャ段階でもイベントを受け取れます
+window.addEventListener('DOMContentLoaded', function () {
     // startButton が存在する場合、クリック時にメッセージを表示して遷移
     var startButton = document.getElementById('startButton');
     if (startButton) {
@@ -18,4 +20,4 @@ window.onload = function() {
             window.location.href = 'game_screen.html';
         }, { once: true });
     });
-};
+}, { capture: true });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -7,11 +7,11 @@ describe('public/start_screen.js', () => {
     document.body.innerHTML = '<button id="startButton"></button>';
     // alertをモック
     global.alert = jest.fn();
-    // start_screen.jsを読み込み、window.onload を実行
+    // start_screen.js を読み込み、DOMContentLoaded を発火させる
     jest.isolateModules(() => {
       require('../public/start_screen.js');
     });
-    window.onload();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
   });
 
   test('ボタンをクリックするとメッセージが表示される', () => {


### PR DESCRIPTION
## 変更点
- `window.onload` を `window.addEventListener('DOMContentLoaded')` に変更
- テスト側では `window.onload()` 呼び出しを `document.dispatchEvent(new Event('DOMContentLoaded'))` へ更新
- 変更に合わせてキャプチャ段階でイベントを受け取るよう修正

## 使い方
1. `npm install` で依存パッケージをインストール
2. `npm start` でサーバーを起動し、ブラウザで `http://localhost:8080/index.html` を開く
3. 画面をタップするとゲーム画面へ遷移

## テスト
- `npm test` を実行し、既存のテストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_68478b168218832ca0257c2edc1704f5