### PR TITLE
サイドドロワーをタップで閉じられるよう改善

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -17,7 +17,7 @@ body {
 
 /* ドロワーの重なり順を明示 */
 #drawer {
-  z-index: 10;
+  z-index: 40;
 }
 
 /* 経済指数の変化を示すアニメーション */
@@ -34,4 +34,17 @@ body {
   /* 左右どちらからでも0位置へ移動 */
   transform: translateX(0) !important;
   transition: transform 0.3s;
+}
+
+/* ドロワー表示中に重ねるオーバーレイ */
+#drawerOverlay {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+  z-index: 30;
+}
+
+#drawerOverlay.overlay-show {
+  opacity: 1;
+  pointer-events: auto;
 }

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -25,6 +25,8 @@
       </span>
     </div>
   </header>
+  <!-- ドロワー用のオーバーレイ -->
+  <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->
   <aside id="drawer" class="fixed top-0 left-0 h-full w-64 -translate-x-full transform transition-transform duration-300 bg-white shadow-lg z-40 flex flex-col relative">
     <nav class="p-4 space-y-4 flex-1">

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -8,6 +8,7 @@ window.addEventListener('DOMContentLoaded', function () {
   const drawer = document.getElementById('drawer');
   const drawerBtn = document.getElementById('drawerBtn');
   const closeDrawerBtn = document.getElementById('closeDrawer');
+  const overlay = document.getElementById('drawerOverlay');
   const statsBtn = document.getElementById('statsBtn');
   const modal = document.getElementById('statsModal');
   const modalBg = document.getElementById('modalBg');
@@ -15,16 +16,26 @@ window.addEventListener('DOMContentLoaded', function () {
 
   // --- ドロワー開閉処理 ----------------------------
   // ボタンを押すと、drawer-open クラスの付け外しで表示を切り替える
-  drawerBtn.addEventListener('click', () => {
-    drawer.classList.toggle('drawer-open');
-  });
+  const openDrawer = () => {
+    drawer.classList.add('drawer-open');
+    overlay.classList.add('overlay-show');
+  };
+
+  const closeDrawer = () => {
+    drawer.classList.remove('drawer-open');
+    overlay.classList.remove('overlay-show');
+  };
+
+  // ボタンを押すとドロワーを開く
+  drawerBtn.addEventListener('click', openDrawer);
 
   // ドロワー内の「戻る」ボタンでも閉じられるようにする
   if (closeDrawerBtn) {
-    closeDrawerBtn.addEventListener('click', () => {
-      drawer.classList.remove('drawer-open');
-    });
+    closeDrawerBtn.addEventListener('click', closeDrawer);
   }
+
+  // オーバーレイをクリックした場合も閉じる
+  overlay.addEventListener('click', closeDrawer);
 
   // --- モーダル表示処理 ----------------------------
   statsBtn.addEventListener('click', () => {

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -87,14 +87,21 @@ function GameScreen() {
 
   // ドロワーの開閉
   const toggleDrawer = () => setDrawerOpen(o => !o);
+  const closeDrawer = () => setDrawerOpen(false);
 
   // ドロワーのclassを状態に応じて生成
   const drawerClasses = [
     'fixed top-0 right-0 h-full w-2/3 sm:w-64',
-    'bg-white shadow-lg z-10 overflow-y-auto',
+    'bg-white shadow-lg z-30 overflow-y-auto',
     'transform transition-transform duration-300',
     'translate-x-full',
     drawerOpen ? 'drawer-open' : ''
+  ].join(' ');
+
+  const overlayClasses = [
+    'fixed inset-0 bg-black/30',
+    'transition-opacity duration-300',
+    drawerOpen ? 'overlay-show' : ''
   ].join(' ');
 
   // 変化量を表示するためのヘルパー
@@ -175,6 +182,12 @@ function GameScreen() {
         )
       )
     ),
+    // ドロワーオーバーレイ
+    React.createElement('div', {
+      id: 'drawerOverlay',
+      className: overlayClasses,
+      onClick: closeDrawer
+    }),
     // ドロワー
     React.createElement(
       'div',


### PR DESCRIPTION
## 変更点
- `game_screen.css` にオーバーレイ用スタイルを追加し、ドロワーの `z-index` を調整
- `game_screen.html` にオーバーレイ要素を追加
- `game_screen.js` でオーバーレイの表示/非表示を制御し、外側タップで閉じる処理を実装
- `game_screen_react.js` も同様にオーバーレイを追加し、クリックで閉じる処理を実装

## テスト
- `npm test` を実行し既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_68478e2d9784832cb1d14d17ab5da173