### PR TITLE
サイドドロワーを統合し主要指数を表示

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -34,7 +34,6 @@
       <button class="w-full text-left py-2 px-3 bg-gray-100 rounded">🗂 クライアント情報</button>
       <button class="w-full text-left py-2 px-3 bg-gray-100 rounded">📜 履歴</button>
     </nav>
-    <button id="closeDrawer" class="absolute bottom-4 right-4 px-3 py-2 bg-gray-100 rounded border">戻る</button>
   </aside>
 
   <!-- モーダル -->

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -3,11 +3,9 @@
 
 // DOMContentLoaded イベントは DOM の構築が終わったときに発火します
 // ページが準備できたら各要素を取得してイベントを設定します
-window.addEventListener('DOMContentLoaded', function () {
   // --- 要素の取得 ----------------------------------
   const drawer = document.getElementById('drawer');
   const drawerBtn = document.getElementById('drawerBtn');
-  const closeDrawerBtn = document.getElementById('closeDrawer');
   const overlay = document.getElementById('drawerOverlay');
   const statsBtn = document.getElementById('statsBtn');
   const modal = document.getElementById('statsModal');
@@ -29,10 +27,6 @@ window.addEventListener('DOMContentLoaded', function () {
   // ボタンを押すとドロワーを開く
   drawerBtn.addEventListener('click', openDrawer);
 
-  // ドロワー内の「戻る」ボタンでも閉じられるようにする
-  if (closeDrawerBtn) {
-    closeDrawerBtn.addEventListener('click', closeDrawer);
-  }
 
   // オーバーレイをクリックした場合も閉じる
   overlay.addEventListener('click', closeDrawer);

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -188,7 +188,7 @@ function GameScreen() {
       className: overlayClasses,
       onClick: closeDrawer
     }),
-    // ドロワー
+    // ドロワー本体
     React.createElement(
       'div',
       {
@@ -198,17 +198,36 @@ function GameScreen() {
       React.createElement(
         'ul',
         { className: 'p-4 space-y-2 text-sm list-none flex-1 overflow-y-auto' },
-        React.createElement('li', { className: 'flex justify-between' }, '為替', React.createElement('span', null, stats.fx.toFixed(1))),
-        React.createElement('li', { className: 'flex justify-between' }, '10年国債', React.createElement('span', null, `${stats.yield.toFixed(1)}%`)),
-        React.createElement('li', { className: 'flex justify-between' }, '消費者信頼感', React.createElement('span', null, stats.cci.toFixed(1))),
-        React.createElement('li', { className: 'flex justify-between' }, 'PMI', React.createElement('span', null, stats.pmi.toFixed(1))),
-        React.createElement('li', { className: 'flex justify-between' }, '財政赤字/GDP', React.createElement('span', null, `${stats.debtGDP.toFixed(1)}%`)),
-        React.createElement('li', { className: 'flex justify-between' }, '貿易収支', React.createElement('span', null, `${stats.trade.toFixed(0)}億円`))
-      ),
-      React.createElement(
-        'button',
-        { onClick: toggleDrawer, className: 'm-4 self-end px-3 py-2 bg-gray-100 rounded border' },
-        '戻る'
+        React.createElement(
+          'li',
+          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          '消費者物価指数',
+          React.createElement('span', null, stats.cpi.toFixed(1))
+        ),
+        React.createElement(
+          'li',
+          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          '失業率',
+          React.createElement('span', null, `${stats.unemp.toFixed(1)}%`)
+        ),
+        React.createElement(
+          'li',
+          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          'GDP成長率',
+          React.createElement('span', null, `${stats.gdp.toFixed(1)}%`)
+        ),
+        React.createElement(
+          'li',
+          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          '政策金利',
+          React.createElement('span', null, `${stats.rate.toFixed(1)}%`)
+        ),
+        React.createElement(
+          'li',
+          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          '財政赤字/GDP比',
+          React.createElement('span', null, `${stats.debtGDP.toFixed(1)}%`)
+        )
       )
     ),
     // トースト


### PR DESCRIPTION
## 変更点
- サイドドロワーの「戻る」ボタンを削除
- React版ドロワーで主要5指数(CPI・失業率・GDP成長率・政策金利・財政赤字/GDP比)をリスト表示
- 非React版からも戻るボタン関連の処理を削除

## テスト
- `npm test` を実行（jest が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_684791f621fc832caa976f00008cf633