### PR TITLE
財政赤字カードをReact版画面に追加

### DIFF
--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -5,6 +5,43 @@
 // ReactからuseRefも取り出しておく
 const { useState, useEffect, useRef } = React;
 
+// 財政赤字/GDP比を大きく表示するカードコンポーネント
+// value: 指標の数値, onClose: 閉じるボタンを押したときの処理
+function DeficitCard({ value, onClose }) {
+  return React.createElement(
+    'div',
+    { className: 'fixed inset-0 flex items-center justify-center z-40' },
+    // 背景の半透明オーバーレイ。クリックでカードを閉じる
+    React.createElement('div', {
+      className: 'absolute inset-0 bg-black/40',
+      onClick: onClose,
+    }),
+    // カード本体
+    React.createElement(
+      'div',
+      { className: 'relative bg-white rounded-lg shadow-lg p-4 z-10 w-11/12 max-w-xs' },
+      React.createElement(
+        'h2',
+        { className: 'text-lg font-bold mb-2 text-center' },
+        '財政赤字/GDP比'
+      ),
+      React.createElement(
+        'p',
+        { className: 'text-3xl font-mono text-center' },
+        `${value.toFixed(1)}%`
+      ),
+      React.createElement(
+        'button',
+        {
+          className: 'mt-4 w-full bg-blue-500 text-white py-1 rounded',
+          onClick: onClose,
+        },
+        '閉じる'
+      )
+    )
+  );
+}
+
 function GameScreen() {
   // 経済指標を状態として管理
   // 10種類の経済指数をまとめて stats というオブジェクトで保持
@@ -25,6 +62,8 @@ function GameScreen() {
   const [history, setHistory] = useState([100]);
   // ドロワー表示のON/OFF
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // 財政赤字カードの表示状態
+  const [showDeficitCard, setShowDeficitCard] = useState(false);
   // 画面右上のトースト用メッセージ
   const [toast, setToast] = useState(null);
   // 指数の前回値を保持するための参照
@@ -215,12 +254,23 @@ function GameScreen() {
         ),
         React.createElement(
           'li',
-          { className: 'flex justify-between p-2 bg-gray-50 rounded' },
+          {
+            className:
+              'flex justify-between p-2 bg-gray-50 rounded cursor-pointer hover:bg-gray-100',
+            onClick: () => setShowDeficitCard(v => !v),
+          },
           '財政赤字/GDP比',
           React.createElement('span', null, `${stats.debtGDP.toFixed(1)}%`)
         )
       )
     ),
+    // 財政赤字カードを必要に応じて表示
+    showDeficitCard
+      ? React.createElement(DeficitCard, {
+          value: stats.debtGDP,
+          onClose: () => setShowDeficitCard(false),
+        })
+      : null,
     // トースト
     toast
       ? React.createElement(


### PR DESCRIPTION
## 変更点
- `DeficitCard` コンポーネントを追加し、財政赤字/GDP比を詳細表示できるようにしました
- `GameScreen` に `showDeficitCard` ステートを追加
- サイドドロワーの「財政赤字/GDP比」クリックでカードを開閉
- ゲーム画面で `DeficitCard` を条件付き表示

## 使い方
1. React 版スタート画面 (`index.html`) からゲーム画面へ遷移します
2. 右上メニューを開き、リストから「財政赤字/GDP比」をタップすると
   詳細カードが表示されます
3. カードの背景または「閉じる」ボタンでカードを閉じられます

## テスト
- `npm test` を実行し既存テストが成功することを確認しました


------
https://chatgpt.com/codex/tasks/task_e_6847b87fca48832ca4757e53462b73d1