### PR TITLE
インジケーター一覧表示の改良

### DIFF
--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -84,6 +84,8 @@ function GameScreen() {
   const [history, setHistory] = useState([100]);
   // ドロワー表示のON/OFF
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // インジケーター一覧表示用の状態
+  const [showIndicators, setShowIndicators] = useState(false);
   // GDPカード表示のON/OFF
   const [showGdpCard, setShowGdpCard] = useState(false);
   // 画面右上のトースト用メッセージ
@@ -147,7 +149,11 @@ function GameScreen() {
 
   // ドロワーの開閉
   const toggleDrawer = () => setDrawerOpen(o => !o);
-  const closeDrawer = () => setDrawerOpen(false);
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    // ドロワーを閉じる際は一覧も閉じておく
+    setShowIndicators(false);
+  };
 
   // ドロワーのclassを状態に応じて生成
   const drawerClasses = [
@@ -251,9 +257,20 @@ function GameScreen() {
         id: 'drawer',
         className: `${drawerClasses} flex flex-col`,
       },
+      // インジケーターボタン
       React.createElement(
-        'ul',
-        { className: 'p-4 space-y-2 text-sm list-none flex-1 overflow-y-auto' },
+        'button',
+        {
+          id: 'statsBtn',
+          className: 'text-left p-3 bg-gray-100 border-b',
+          onClick: () => setShowIndicators(o => !o),
+        },
+        '📊 経済指標'
+      ),
+      showIndicators &&
+        React.createElement(
+          'ul',
+          { className: 'p-4 space-y-2 text-sm list-none flex-1 overflow-y-auto' },
         React.createElement(
           'li',
           { className: 'flex justify-between p-2 bg-gray-50 rounded' },


### PR DESCRIPTION
## 変更点
- サイドドロワーに「経済指標」ボタンを追加し，押すと指標の一覧を展開するように変更
- ドロワーを閉じた際は指標一覧も閉じる処理を追加
- React コンポーネント内の状態を調整

## 使い方
ゲーム画面右上の ☰ ボタンでドロワーを開き，「📊 経済指標」を押すと指標一覧が表示されます。各項目を押すと従来通り詳細カードが表示されます。

------
https://chatgpt.com/codex/tasks/task_e_6847c1438a40832caf7574432ee29c1c