### PR TITLE
Googleフォントと背景設定を修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ECON – Start</title>
 
+  <!-- Google フォントを事前接続 -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
+
   <!-- Tailwind の CDN を読み込み -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- 外部CSSを読み込み -->
@@ -14,15 +19,10 @@
 </head>
   <body class="select-none">
     <!-- 背景画像を全画面に表示 -->
-    <div class="relative w-full h-screen bg-cover bg-center bright-background" style="background-image: url('/images/game_screen.webp')">
-      <!-- タイトル位置を調整して中央付近に表示 -->
-      <div class="absolute top-1/3 w-full flex justify-center">
-        <!-- タイトルの背面に半透明のオーバーレイを敷く -->
-        <div class="bg-black bg-opacity-50 px-4 py-2">
-          <h1 class="text-white text-5xl md:text-6xl font-bold drop-shadow-md">
-            ECON
-          </h1>
-        </div>
+    <div class="relative w-full h-screen start-screen-background bright-background">
+      <!-- 画面上部にメッセージを表示 -->
+      <div class="absolute top-0 w-full text-center py-4">
+        <span class="text-white text-2xl font-bold">戦略で導け！</span>
       </div>
     </div>
   </body>

--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -2,10 +2,20 @@
 body {
     margin: 0;
     padding: 0;
+    /* Google フォントを適用 */
+    font-family: "Noto Sans JP", "Zen Maru Gothic", sans-serif;
 }
 
 /* 背景画像を明るくするクラス */
 .bright-background {
     filter: brightness(1.3); /* 明度を30%アップ */
+}
+
+/* スタート画面用の背景画像を設定 */
+.start-screen-background {
+    /* 画像を全画面に表示し、中央に配置 */
+    background-image: url("images/title.webp");
+    background-size: cover;
+    background-position: center;
 }
 


### PR DESCRIPTION
## 概要
- スタート画面で `Noto Sans JP` と `Zen Maru Gothic` を利用
- 背景画像は CSS から `title.webp` を参照するように変更
- 中央タイトルを削除し、画面上部に「戦略で導け！」を表示
- バイナリファイルの追加を避けるため、画像 `title.webp` を削除

## 使い方
`public/index.html` をブラウザで開くと、画面上部に「戦略で導け！」が表示されます。画面をクリックするとゲーム画面へ遷移します。

## テスト
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6848e105f318832c81097f487694d5d9