### PR TITLE
スタート画面のデザイン改善

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,11 @@
 
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Google Fonts を事前接続 -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <!-- Noto Sans JP と Zen Maru Gothic を読み込み -->
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
   <!-- 外部CSSを読み込み -->
   <link rel="stylesheet" href="start_screen.css" />
   

--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -7,6 +7,8 @@ body {
     background-size: cover;             /* PCでは画面いっぱいに表示 */
     margin: 0;
     padding: 0;
+    /* フォントをGoogleフォントで統一 */
+    font-family: 'Noto Sans JP', 'Zen Maru Gothic', sans-serif;
 }
 
 /* スマホでは画像全体が収まるように調整 */

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -24,20 +24,20 @@ function StartScreen() {
 
   // JSX で画面の見た目を記述します
   return (
-    // divを画面いっぱいに広げ、中央にタイトルを表示します
+    // divを画面いっぱいに広げ、画面上部にキャッチコピーを表示します
     React.createElement(
       'div',
       {
-        className: 'h-screen w-screen flex items-center justify-center select-none',
+        className: 'h-screen w-screen flex items-center justify-center select-none relative',
         onClick: handleClick,
       },
       React.createElement(
-        'h1',
+        'div',
         {
           className:
-            'text-6xl font-extrabold tracking-wider text-blue-500 drop-shadow-lg animate-pulse',
+            'absolute top-0 left-0 w-full text-center py-4 bg-black/50 text-white text-xl md:text-2xl font-bold',
         },
-        'ECON'
+        '戦略で導け！'
       )
     )
   );


### PR DESCRIPTION
## 概要
- スタート画面に Google フォントを読み込み
- スタート画面上部にキャッチコピー「戦略で導け！」を追加
- 画面中央の "ECON" 表示を削除
- CSS にフォント設定を追加

## 使い方
1. `npm start` でサーバーを起動し `http://localhost:8080` にアクセスします。
2. 画面をクリックするとゲーム画面へ遷移します。

## テスト
- `npm test` を実行し、既存テストが成功することを確認済み

------
https://chatgpt.com/codex/tasks/task_e_6848e825f0c4832c8129688f76097104