### PR TITLE
UI調整：キャッチコピーとヘッダー

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -48,3 +48,9 @@ body {
   opacity: 1;
   pointer-events: auto;
 }
+
+/* 立体的な文字を表現するクラス */
+.three-d-text {
+  color: #fff;
+  text-shadow: 2px 2px 0 #999, 4px 4px 0 #666, 6px 6px 0 #333;
+}

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -197,7 +197,7 @@ function GameScreen() {
       React.createElement(
         'div',
         { className: 'flex justify-between items-center' },
-        React.createElement('h1', { className: 'text-2xl font-bold' }, 'ECON'),
+        React.createElement('h1', { className: 'text-2xl font-bold three-d-text' }, 'ECON'),
         React.createElement('button', { onClick: toggleDrawer, className: 'text-2xl' }, '☰')
       ),
       // 主要4指数を大きめに表示
@@ -211,7 +211,7 @@ function GameScreen() {
           'div',
           {
             className:
-              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 text-sky-200 font-bold',
           },
           `CPI: ${stats.cpi.toFixed(1)}`,
           diffElement(diffStats.cpi)
@@ -220,7 +220,7 @@ function GameScreen() {
           'div',
           {
             className:
-              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 text-sky-200 font-bold',
           },
           `失業率: ${stats.unemp.toFixed(1)}%`,
           diffElement(diffStats.unemp)
@@ -229,7 +229,7 @@ function GameScreen() {
           'div',
           {
             className:
-              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 text-sky-200 font-bold',
           },
           `金利: ${stats.rate.toFixed(1)}%`,
           diffElement(diffStats.rate)
@@ -238,7 +238,7 @@ function GameScreen() {
           'div',
           {
             className:
-              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 shadow-inner text-sky-200 font-bold',
+              'bg-sky-700/30 border border-sky-500 rounded-xl px-4 py-2 text-sky-200 font-bold',
           },
           `GDP: ${stats.gdp.toFixed(1)}%`,
           diffElement(diffStats.gdp)

--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -23,3 +23,10 @@ h1 {
     color: #3b82f6; /* 青色 */
 }
 
+/* 立体的な文字を表すクラス */
+.three-d-text {
+    /* 白い文字に段差のような影を重ねる */
+    color: #fff;
+    text-shadow: 2px 2px 0 #999, 4px 4px 0 #666, 6px 6px 0 #333;
+}
+

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -34,8 +34,8 @@ function StartScreen() {
       React.createElement(
         'div',
         {
-          className:
-            'absolute top-0 left-0 w-full text-center py-4 bg-black/50 text-white text-xl md:text-2xl font-bold',
+          className: 'absolute top-0 left-0 w-full text-center font-bold three-d-text',
+          style: { fontSize: '25vh' }
         },
         '戦略で導け！'
       )


### PR DESCRIPTION
## 概要
- スタート画面のキャッチコピーを画面上部で大きく表示
- ヘッダーの指標カードから影を削除
- ヘッダーのタイトルとキャッチコピーに立体的な文字効果を追加

## 動作確認
- `npm test` を実行したが `jest` が見つからずテストは未実行

------
https://chatgpt.com/codex/tasks/task_e_6848ea328690832c90f9ba27ecbbff58