### PR TITLE
キャッチコピーの塗り重ね色を指定カラーで調整

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -24,9 +24,43 @@ h1 {
 }
 
 /* 立体的な文字を表すクラス */
+
 .three-d-text {
     /* 白い文字に段差のような影を重ねる */
     color: #fff;
     text-shadow: 2px 2px 0 #999, 4px 4px 0 #666, 6px 6px 0 #333;
+}
+
+/* ===============================================
+   キャッチコピー用のカラフルな塗り重ね表現
+   - 半透明の色をいくつも重ねたような効果を狙う
+   - ブラウザによっては背景色がはみ出さないよう
+     background-clip を指定する
+================================================ */
+.painted-text {
+    /* 色を透明度付きで複数重ねる */
+    background-image:
+        /* #aae2dd をベースにした淡い色 */
+        radial-gradient(circle at 20% 30%, rgba(170, 226, 221, 0.7), transparent 60%),
+        /* 深みのある #167289 を重ねる */
+        radial-gradient(circle at 80% 40%, rgba(22, 114, 137, 0.6), transparent 60%),
+        /* アクセントに #1da689 を使用 */
+        radial-gradient(circle at 40% 70%, rgba(29, 166, 137, 0.6), transparent 60%),
+        /* もう一度 #aae2dd 系の色で全体をなじませる */
+        radial-gradient(circle at 60% 20%, rgba(170, 226, 221, 0.5), transparent 60%);
+    background-blend-mode: multiply;
+    background-size: 200% 200%;
+    background-position: center;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;       /* 塗りを背景で表現するため文字色は透明 */
+    animation: flowColors 15s linear infinite;
+}
+
+/* 背景の色がゆっくり流れるように動かす */
+@keyframes flowColors {
+    0%   { background-position: 0% 0%; }
+    50%  { background-position: 100% 100%; }
+    100% { background-position: 0% 0%; }
 }
 

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -32,11 +32,11 @@ function StartScreen() {
         onClick: handleClick,
       },
       React.createElement(
-        'div',
-        {
-          className: 'absolute top-0 left-0 w-full text-center font-bold three-d-text',
-          style: { fontSize: '25vh' }
-        },
+      'div',
+      {
+        className: 'absolute top-0 left-0 w-full text-center font-bold three-d-text painted-text',
+        style: { fontSize: '25vh' }
+      },
         '戦略で導け'
       )
     )


### PR DESCRIPTION
## 変更内容
- `.painted-text` クラスのグラデーション色を `#aae2dd`・`#167289`・`#1da689` を中心とした配色に変更
- コメントを追加し、各色の意味をわかりやすく記述

## 使い方
- `index.html` をブラウザで開き、画面をタップするとゲーム画面へ進みます
- 上部のキャッチコピーが指定カラーでゆっくり動く演出を確認できます

## テスト結果
- `npm install` を実行し依存関係を準備
- `npm test --silent` を実行し既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_6848f7a39958832cb468faa6355c7d08