### PR TITLE
スタート画面のタイトル色と演出を修正

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -26,24 +26,38 @@ h1 {
 /* 立体的な文字を表すクラス */
 
 .three-d-text {
-    /* 白い文字に段差のような影を重ねる */
-    color: #fff;
+    /* 立体感を出すために影を付ける */
     text-shadow: 2px 2px 0 #999, 4px 4px 0 #666, 6px 6px 0 #333;
+    position: relative;             /* 擬似要素を重ねるために必要 */
+    overflow: hidden;               /* 光の演出がはみ出ないようにする */
 }
 
 /* ===============================================
-   キャッチコピー用のグラデーション設定
-   - 文字上部をやや暗めの色 (#255c83)
-   - 下部を明るい色 (#1da689) にして立体感を出す
-   - 背景のグラデーションで文字を塗りつぶす
-   - ブラウザによってははみ出さないよう
-     background-clip を指定する
+   タイトルテキスト用のカラー設定
+   - 落ち着いた紺色を基調とする
+   - 擬似要素で右から光が当たる演出を追加
 ================================================ */
 .painted-text {
-    /* 文字上部を #255c83、下部を #1da689 にしたグラデーション */
-    background-image: linear-gradient(to bottom, #255c83, #1da689);
-    -webkit-background-clip: text;  /* 背景のグラデーションで文字を塗る */
-    background-clip: text;
-    color: transparent; /* グラデーションを表示するため文字色は透明 */
+    /* 黒に近い紺色を基調としたタイトルカラー */
+    color: #0a1f40;
+}
+
+/* タイトルを右から照らす光のアニメーション */
+.painted-text::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 100%;
+    width: 50%;
+    height: 100%;
+    background: linear-gradient(to left, rgba(255,255,255,0.7), rgba(255,255,255,0));
+    transform: skewX(-20deg);
+    animation: shine 3s infinite;
+    pointer-events: none; /* クリック判定を邪魔しない */
+}
+
+@keyframes shine {
+    from { left: 100%; }
+    to   { left: -50%; }
 }
 


### PR DESCRIPTION
## 変更内容
- `start_screen.css` にて `painted-text` クラスの色を紺色 (#0a1f40) に変更
- 擬似要素とアニメーションを追加し、右から光が当たる演出を実装
- `three-d-text` クラスを修正し、光の演出用に位置指定を追加
- テストを実行し動作を確認

## 使い方
1. `npm start` でサーバーを起動
2. ブラウザで `http://localhost:8080/index.html` を開く
3. タイトル「econ」をクリックまたは画面をタップするとゲーム画面へ移動


------
https://chatgpt.com/codex/tasks/task_e_68490bf79858832cbb5c19f759f611d8