### PR TITLE
スポットライト演出の速度調整

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -42,21 +42,32 @@ h1 {
     color: #0a1f40;
 }
 
-/* タイトルを右から照らす光のアニメーション */
-.painted-text::after {
+/* ===============================================
+   テキストと周囲を照らすスポットライト演出
+   - 擬似要素を使って右から左へ光が流れる
+================================================ */
+.spotlight-text {
+    /* タイトル文字の基本色 */
+    color: #0a1f40;
+    position: relative;
+    overflow: hidden; /* 光の演出がはみ出さないように */
+}
+
+/* 右から左へ流れるスポットライト */
+.spotlight-text::after {
     content: '';
     position: absolute;
     top: 0;
     left: 100%;
     width: 50%;
     height: 100%;
-    background: linear-gradient(to left, rgba(255,255,255,0.7), rgba(255,255,255,0));
+    background: linear-gradient(to left, rgba(255,255,255,0.8), rgba(255,255,255,0));
     transform: skewX(-20deg);
-    animation: shine 3s infinite;
+    animation: spotlight 6s infinite; /* 速度を 50% 遅くする */
     pointer-events: none; /* クリック判定を邪魔しない */
 }
 
-@keyframes shine {
+@keyframes spotlight {
     from { left: 100%; }
     to   { left: -50%; }
 }

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -34,7 +34,7 @@ function StartScreen() {
       React.createElement(
       'div',
       {
-        className: 'absolute left-0 w-full text-center font-bold three-d-text painted-text',
+        className: 'absolute left-0 w-full text-center font-bold three-d-text painted-text spotlight-text',
         style: { fontSize: '25vh', top: '-8px' }
       },
         'econ'


### PR DESCRIPTION
## 変更内容
- `.spotlight-text` のアニメーションを `::after` 擬似要素で再実装
- 光の流れる速さを 6 秒周期に変更し、従来より 50% 低速化
- コメントを整理して効果の内容を明確化

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68491283b7d0832cacdfb7db6a885680