### PR TITLE
スタート画面タイトルのグラデーションをアニメーション化

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -71,3 +71,27 @@ h1 {
     to   { background-position: -200% 0; }
 }
 
+/* ========================================================
+   タイトルの文字色をグラデーションで変化させる演出
+   - 青 → 紺 → 黒 の配色を時間経過で循環させる
+   - 文字自体を背景グラデーションで描画
+======================================================== */
+.gradient-cycle-text {
+    /* 3色のグラデーションを用意し背景として設定 */
+    background-image: linear-gradient(90deg, #3b82f6, #0a1f40, #000, #3b82f6);
+    /* グラデーションを大きめにして動きを強調 */
+    background-size: 300% 100%;
+    /* 文字の形で背景を切り抜き、色を透明にする */
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    /* 時間とともにグラデーションを左右に移動させる */
+    animation: gradient-cycle 6s linear infinite;
+}
+
+@keyframes gradient-cycle {
+    0%   { background-position:   0% 50%; }
+    50%  { background-position: 100% 50%; }
+    100% { background-position:   0% 50%; }
+}
+

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -34,7 +34,7 @@ function StartScreen() {
       React.createElement(
       'div',
       {
-        className: 'absolute left-0 w-full text-center font-bold three-d-text painted-text spotlight-text',
+        className: 'absolute left-0 w-full text-center font-bold three-d-text gradient-cycle-text',
         style: { fontSize: '25vh', top: '-8px' }
       },
         'econ'


### PR DESCRIPTION
## 概要
- スタート画面タイトルの色を青→紺→黒へ循環するグラデーションに変更
- アニメーション用のCSSクラス `gradient-cycle-text` を追加
- React版スタート画面で新しいクラスを適用

## 使い方
`public/index.html` を開くとスタート画面が表示されます。タイトル文字に時間とともに変化するグラデーションがかかります。画面をクリックするとゲーム画面へ移動します。

## テスト
- `npm test` を実行しましたが、環境に jest が無いため失敗しました。


------
https://chatgpt.com/codex/tasks/task_e_68491bc2f460832caacc2f3cc4c6c541