### PR TITLE
CSSのスポットライト速度を修正

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -64,8 +64,8 @@ h1 {
     color: transparent;
     background-size: 200% 100%;
     background-position: 200% 0;
-    /* スポットライトの速さを9秒に変更 */
-    animation: spotlight 9s infinite;
+    /* スポットライトの速さを2秒に変更 */
+    animation: spotlight 2s linear infinite;
 }
 
 @keyframes spotlight {


### PR DESCRIPTION
## 概要
- start_screen.css の `.spotlight-text` クラスに設定していたアニメーション速度を9秒から2秒へ変更しました
- コメントも合わせて2秒表記に更新しました

## 動作確認
- `npm install` で依存パッケージを導入
- `npm test` を実行し、既存テストがパスすることを確認
- `npm start` でサーバーを立ち上げ、ブラウザから `index.html` を確認し、タイトルのスポットライトが2秒で1周することを確認しました


------
https://chatgpt.com/codex/tasks/task_e_684920fb04c0832c8e60e4bc8b87eb5c