### PR TITLE
CSSのスポットライト速度を6秒に変更

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -64,8 +64,8 @@ h1 {
     color: transparent;
     background-size: 200% 100%;
     background-position: 200% 0;
-    /* スポットライトの速さを9秒に変更 */
-    animation: spotlight 9s infinite;
+    /* スポットライトの速さを6秒に変更 */
+    animation: spotlight 6s linear infinite;
 }
 
 @keyframes spotlight {


### PR DESCRIPTION
## 概要
- `.spotlight-text` クラスのアニメーション速度を 6 秒に変更しました
- コメントも 6 秒表記に更新しました

## 動作確認
- `npm install` を実行し依存パッケージを導入
- `npm test` を実行し既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_684920fb04c0832c8e60e4bc8b87eb5c