### PR TITLE
ブルーグラデーションのタイトルへ変更

### DIFF
--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -49,21 +49,22 @@ h1 {
    - 右から左へハイライトが移動する
 ================================================ */
 .spotlight-text {
-    /* 文字色は黒 */
-    color: #000;
-    /* 背景グラデーションでハイライトを作る */
-    background-image: linear-gradient(
-        to left,
-        transparent 45%,
-        rgba(255,255,255,0.8) 50%,
-        transparent 55%
-    );
-    /* ハイライト部分だけ文字として表示 */
+    /* 鮮やかなブルーのグラデーションを基本色とする */
+    background-image:
+        linear-gradient(to right, #33ccff, #3366ff),
+        linear-gradient(
+            to left,
+            transparent 45%,
+            rgba(255,255,255,0.8) 50%,
+            transparent 55%
+        );
+    /* 文字としてグラデーションを表示 */
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
-    background-size: 200% 100%;
-    background-position: 200% 0;
+    /* 1つ目のグラデーションは固定、2つ目をアニメーション */
+    background-size: 100% 100%, 200% 100%;
+    background-position: 0 0, 200% 0;
     /* スポットライトの速さを6秒に変更 */
     animation: spotlight 6s linear infinite;
 }


### PR DESCRIPTION
## 概要
スタート画面のタイトル文字「econ」を鮮やかなブルーのグラデーションで表示するようCSSを調整しました。アニメーションするスポットライト効果は維持しつつ、ベースカラーを青系グラデーションにしています。

## 主な変更点
- `public/start_screen.css` の `.spotlight-text` クラスを編集し、青系グラデーションとハイライトを二重背景で実装
- 既存のテストを実行し、すべて成功することを確認

## 使い方
`public/index.html` をブラウザで開くとスタート画面が表示されます。画面をクリックするとゲーム画面へ進みます。タイトル文字はブルーのグラデーションで表示されます。


------
https://chatgpt.com/codex/tasks/task_e_6849263c47c0832cbea9c56446a5ac2c