### PR TITLE
スタート画面のタイトルデザイン更新

### DIFF
--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -32,12 +32,13 @@ function StartScreen() {
         onClick: handleClick,
       },
       React.createElement(
-      'div',
-      {
-        className: 'absolute left-0 w-full text-center font-bold three-d-text painted-text spotlight-text',
-        style: { fontSize: '25vh', top: '-8px' }
-      },
-        'econ'
+        'h1',
+        {
+          className:
+            'text-6xl font-extrabold text-[#00fb00] animate-pulse drop-shadow-[0_0_5px_#00fb00] absolute left-0 w-full text-center',
+          style: { top: '-8px' }
+        },
+        'ECON'
       )
     )
   );


### PR DESCRIPTION
## 概要
- React版スタート画面のタイトルを緑色のパルスアニメーション付きデザインに変更しました
- 既存のテストを実行し、成功を確認しています

## 使い方
- `npm start` で `public/index.html` を開き、画面をタップするとゲーム画面へ遷移します

------
https://chatgpt.com/codex/tasks/task_e_684a183d86d8832c8a36121017704a81