### PR TITLE
スタート画面の改善

### DIFF
--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -32,13 +32,35 @@ function StartScreen() {
         onClick: handleClick,
       },
       React.createElement(
-        'h1',
-        {
-          className:
-            'text-6xl font-extrabold text-[#00fb00] animate-pulse drop-shadow-[0_0_5px_#00fb00] absolute left-0 w-full text-center',
-          style: { top: '-8px' }
-        },
-        'ECON'
+        'div',
+        { className: 'text-center' },
+        // タイトル文字
+        React.createElement(
+          'h1',
+          {
+            className:
+              'text-6xl font-extrabold text-[#00fb00] animate-pulse drop-shadow-[0_0_5px_#00fb00] absolute left-0 w-full text-center',
+            style: { top: '-8px' }
+          },
+          "Let's Go"
+        ),
+        // 画面タップを促す説明文
+        React.createElement(
+          'p',
+          {
+            className: 'relative mt-16 text-white text-lg'
+          },
+          '画面をタップしてスタート'
+        ),
+        // 明確な開始ボタン
+        React.createElement(
+          'button',
+          {
+            onClick: handleClick,
+            className: 'mt-4 px-6 py-2 bg-[#00fb00] text-black font-bold rounded shadow'
+          },
+          '開始'
+        )
       )
     )
   );


### PR DESCRIPTION
## 概要
- React版スタート画面のタイトルを `Let's Go` に変更
- 画面タップを促す説明文と明確な「開始」ボタンを追加

## 動作確認
- `npm test` を実行し既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_684a1cbcdf0c832cb033ce8010208b43