### PR TITLE
スタート画面UIの微調整

### DIFF
--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -31,14 +31,23 @@ function StartScreen() {
         className: 'h-screen w-screen flex items-center justify-center select-none relative',
         onClick: handleClick,
       },
+      // タイトル文字
       React.createElement(
         'h1',
         {
           className:
-            'text-6xl font-extrabold text-[#00fb00] animate-pulse drop-shadow-[0_0_5px_#00fb00] absolute left-0 w-full text-center',
-          style: { top: '-8px' }
+            'font-extrabold text-[#00fb00] animate-pulse drop-shadow-[0_0_5px_#00fb00] absolute left-0 w-full text-center',
+          style: { fontSize: '25vh', top: '-8px' }
         },
-        'ECON'
+        "Let's Go"
+      ),
+      // 画面右下に「画面をタップ」テキストを表示
+      React.createElement(
+        'p',
+        {
+          className: 'absolute bottom-4 right-4 text-white text-lg'
+        },
+        '画面をタップ'
       )
     )
   );


### PR DESCRIPTION
## 概要
- React版スタート画面からボタンを削除
- タイトルを従来の大サイズに戻し、右下に「画面をタップ」を表示
- 既存テストを実行して動作確認

## 動作確認
- `npm test --silent` が成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_684a1cbcdf0c832cb033ce8010208b43