### PR TITLE
スタート画面の遷移テストを追加

### DIFF
--- a/tests/start_screen_react.test.js
+++ b/tests/start_screen_react.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const React = require('react');
+const ReactDOM = require('react-dom/client');
+const { act } = require('react-dom/test-utils');
+
+describe('StartScreen React', () => {
+  test('画面クリックで game_screen_react.html に遷移しようとする', () => {
+    // HTML を読み込んで DOM にセット
+    const html = fs.readFileSync(path.join(__dirname, '../public/index.html'), 'utf8');
+    document.documentElement.innerHTML = html;
+
+    // React と ReactDOM をグローバルに登録
+    global.React = React;
+    global.ReactDOM = ReactDOM;
+
+    // スタート画面スクリプトを実行
+    act(() => {
+      require('../public/start_screen_react.js');
+    });
+
+    const clickable = document.getElementById('root').firstElementChild;
+
+    // console.error を監視してナビゲーションエラーが出るかチェック
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    clickable.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const errorCalled = errorSpy.mock.calls.some(args => String(args[0]).includes('navigation'));
+    errorSpy.mockRestore();
+    expect(errorCalled).toBe(true);
+
+    // スクリプトに遷移先が記述されているか確認
+    const scriptText = fs.readFileSync(path.join(__dirname, '../public/start_screen_react.js'), 'utf8');
+    expect(scriptText).toContain('game_screen_react.html');
+  });
+});


### PR DESCRIPTION
## 概要
- React版スタート画面(`index.html`)をjsdom環境で読み込み、画面クリック時に`game_screen_react.html`への遷移を試みるかどうかを確認するテストを追加しました。
- 既存設定でテストが実行できるため`package.json`の変更は不要です。

## 使い方
1. `npm install`
2. `npm test`

## 簡単なアプリの使い方
`public/index.html`をブラウザで開き、画面をクリックするとReact版ゲーム画面へ遷移します。

------
https://chatgpt.com/codex/tasks/task_e_684a42620908832c9d1e5ec2a3f8f683