### PR TITLE
スパークライン表示のサイズ調整

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -56,8 +56,17 @@ body {
 }
 
 /* スパークライン用のスタイル */
-.sparkline {
+.sparkline-container {
+  /* カード内で8pxの余白をとる */
+  padding: 8px;
+  /* 親要素の幅に合わせつつ padding を含めた幅計算にする */
   width: 100%;
-  height: 120px; /* 30ターン分でも見やすい高さに調整 */
+  box-sizing: border-box;
+}
+
+.sparkline {
+  /* 親要素いっぱいに広げる */
+  width: 100%;
+  height: auto;
   display: block;
 }


### PR DESCRIPTION
## 概要
- `.sparkline-container` に `width: 100%` と `box-sizing: border-box` を追加
- カード内でスパークラインが親要素より大きくならないよう修正

## 使い方
`npm install` 実行後、`npm test` でテストできます。

## テスト結果
- `npm test` を実行し、2 件のテストが成功することを確認しました


------
https://chatgpt.com/codex/tasks/task_e_684a493d2e60832c861e57a5d2dc1c96