### PR TITLE
スパークライン表示の再調整

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -56,8 +56,18 @@ body {
 }
 
 /* スパークライン用のスタイル */
-.sparkline {
+.sparkline-container {
+  /* カード内で 8px の余白をとる */
+  padding: 8px;
+  /* 親要素の幅に合わせつつ padding を含めた幅計算にする */
   width: 100%;
-  height: 120px; /* 30ターン分でも見やすい高さに調整 */
+  box-sizing: border-box;
+  /* グラフを中央寄せにする */
+  display: flex;
+  justify-content: center;
+}
+
+.sparkline {
+  /* サイズは React 側で指定するのでここでは自動 */
   display: block;
 }

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -17,10 +17,27 @@ function Sparkline({ history }) {
   // 履歴がなければ描画しない
   if (!history || history.length === 0) return null;
 
-  // SVG のサイズ
-  // カード幅いっぱいに広げて高さも大きめに
-  const svgWidth = 300; // 表示用の横幅
-  const svgHeight = 120; // 表示用の縦幅
+  // 親要素のサイズを取得するための参照
+  const containerRef = useRef(null);
+  // SVG の幅と高さを状態として管理
+  const [size, setSize] = useState({ w: 300, h: 150 });
+
+  useEffect(() => {
+    // 描画後に親要素の幅を取得してサイズを更新
+    const update = () => {
+      if (containerRef.current) {
+        // カード幅からパディングを除いた値を基準にする
+        const base = containerRef.current.clientWidth - 16;
+        // 幅はカード幅の 5/6、高さはカード幅の 1/2 に設定
+        const w = base * 5 / 6;
+        const h = base / 2;
+        setSize({ w, h });
+      }
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
 
   // 最小値と最大値を求めてY座標を正規化
   const min = Math.min(...history);
@@ -28,29 +45,34 @@ function Sparkline({ history }) {
   const range = max - min || 1;
 
   // データ数からX軸の間隔を求める
-  const step = svgWidth / (history.length - 1);
+  const step = size.w / (history.length - 1);
   // 各点を"x,y"形式で並べる
   const points = history
     .map((v, i) => {
       const x = i * step;
-      const y = svgHeight - ((v - min) / range) * svgHeight;
+      const y = size.h - ((v - min) / range) * size.h;
       return `${x},${y}`;
     })
     .join(' ');
 
   // 折れ線グラフと目盛り軸を描画
   return React.createElement(
-    'svg',
-    {
-      viewBox: `0 0 ${svgWidth} ${svgHeight}`,
-      className: 'sparkline',
-    },
+    'div',
+    { ref: containerRef, className: 'sparkline-container' },
+    React.createElement(
+      'svg',
+      {
+        viewBox: `0 0 ${size.w} ${size.h}`,
+        width: size.w,
+        height: size.h,
+        className: 'sparkline',
+      },
     // 横軸
     React.createElement('line', {
       x1: 0,
-      y1: svgHeight,
-      x2: svgWidth,
-      y2: svgHeight,
+      y1: size.h,
+      x2: size.w,
+      y2: size.h,
       stroke: '#ccc',
       strokeWidth: 1,
     }),
@@ -59,7 +81,7 @@ function Sparkline({ history }) {
       x1: 0,
       y1: 0,
       x2: 0,
-      y2: svgHeight,
+      y2: size.h,
       stroke: '#ccc',
       strokeWidth: 1,
     }),
@@ -80,17 +102,18 @@ function Sparkline({ history }) {
     // 最小値ラベル
     React.createElement('text', {
       x: 2,
-      y: svgHeight - 2,
+      y: size.h - 2,
       fontSize: '10',
       fill: '#555'
     }, min.toFixed(1)),
     // 横軸ラベル（時間）
     React.createElement('text', {
-      x: svgWidth - 24,
-      y: svgHeight - 2,
+      x: size.w - 24,
+      y: size.h - 2,
       fontSize: '10',
       fill: '#555'
     }, '時間')
+    )
   );
 }
 
@@ -134,13 +157,13 @@ function IndicatorCard(props) {
         { className: 'text-lg font-bold' },
         props.title
       ),
+      // カード上部にスパークラインを表示
+      React.createElement(Sparkline, { history: props.history }),
       React.createElement(
         'p',
         { className: 'text-3xl font-mono text-center' },
         `${props.value.toFixed(1)}${props.unit}`
       ),
-      // 過去の推移を折れ線グラフで表示
-      React.createElement(Sparkline, { history: props.history }),
       React.createElement(
         'p',
         { className: 'text-sm text-gray-600' },


### PR DESCRIPTION
## 概要
- スパークラインの幅をカード幅の 5/6、高さを 1/2 として計算するよう変更
- グラフをカード上部に移動
- CSS を調整し中央寄せで表示

## 使い方
`npm install` の後、`npm test` でテストできます。

## テスト結果
- `npm test` を実行し、2 件のテストが成功することを確認しました

------
https://chatgpt.com/codex/tasks/task_e_684a493d2e60832c861e57a5d2dc1c96