### PR TITLE
スパークラインのサイズ調整

### DIFF
--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -20,6 +20,7 @@ function Sparkline({ history }) {
   // 親要素のサイズを取得するための参照
   const containerRef = useRef(null);
   // SVG の幅と高さを状態として管理
+  // 初期サイズを適当に設定
   const [size, setSize] = useState({ w: 300, h: 150 });
 
   useEffect(() => {
@@ -27,10 +28,10 @@ function Sparkline({ history }) {
     const update = () => {
       if (containerRef.current) {
         // カード幅からパディングを除いた値を基準にする
-        const base = containerRef.current.clientWidth - 16;
-        // 幅はカード幅の 5/6、高さはカード幅の 1/2 に設定
-        const w = base * 5 / 6;
-        const h = base / 2;
+        const base = containerRef.current.clientWidth - 16; // パディングを除いた値
+        // グラフをカード幅いっぱいに広げる
+        const w = base;
+        const h = base / 2; // 高さは幅に対して 1/2 程度
         setSize({ w, h });
       }
     };
@@ -58,7 +59,8 @@ function Sparkline({ history }) {
   // 折れ線グラフと目盛り軸を描画
   return React.createElement(
     'div',
-    { ref: containerRef, className: 'sparkline-container' },
+    // 高さはTailwindのh-32を参考に設定
+    { ref: containerRef, className: 'sparkline-container h-32 w-full' },
     React.createElement(
       'svg',
       {


### PR DESCRIPTION
## 変更内容
- Sparkline コンポーネントでカード幅いっぱいにグラフを表示するよう更新
- 高さの目安として `h-32` を付与し、カードサイズに合わせて描画

## テスト結果
- `npm test` を実行し、既存のテストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_684a4ef9ca04832cbe99a5d81fa37fcd