### PR TITLE
スパークラインとカードUI改善

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -65,9 +65,21 @@ body {
   /* グラフを中央寄せにする */
   display: flex;
   justify-content: center;
+  /* 横幅を広げた際にスクロールできるようにする */
+  overflow-x: auto;
 }
 
 .sparkline {
   /* サイズは React 側で指定するのでここでは自動 */
   display: block;
+}
+
+/* カードを閉じるためのバツボタン */
+.close-btn {
+  position: absolute;
+  top: 0.5rem; /* Tailwindでいうtop-2*/
+  right: 0.5rem; /* Tailwindでいうright-2*/
+  font-size: 1.25rem; /* text-xl */
+  font-weight: bold;
+  cursor: pointer;
 }

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -28,8 +28,9 @@ function Sparkline({ history }) {
       if (containerRef.current) {
         // カード幅からパディングを除いた値を基準にする
         const base = containerRef.current.clientWidth - 16;
-        // 幅はカード幅の 5/6、高さはカード幅の 1/2 に設定
-        const w = base * 5 / 6;
+        // 幅を従来の2倍にし、高さはカード幅の 1/2 のまま
+        // base * 5 / 6 が元の計算なので *2 している
+        const w = (base * 5 / 6) * 2;
         const h = base / 2;
         setSize({ w, h });
       }
@@ -144,11 +145,12 @@ function IndicatorCard(props) {
           'relative bg-white rounded-xl shadow-lg w-11/12 h-5/6 max-w-none p-4 space-y-3 z-10',
       },
       // 右上に閉じるボタン
+      // 閉じるためのバツボタン
       React.createElement(
         'button',
         {
           onClick: props.onClose,
-          className: 'absolute top-2 right-2 text-xl',
+          className: 'close-btn',
         },
         '✕'
       ),


### PR DESCRIPTION
## 変更内容
- 指標カード内スパークラインの横幅を2倍に拡大
- スパークライン容器にスクロール許可を追加
- カード右上に閉じるボタン用クラス `close-btn` を追加し見やすく配置
- 閉じるボタンを `IndicatorCard` から操作できるよう修正

## 動作確認
- `npm test` を実行し既存テスト2件が成功することを確認

## 使い方メモ
1. `npm start` でサーバーを起動
2. ブラウザで `index.html` を開き、ゲームを開始
3. ドロワーから指標を選ぶとカードが表示され、右上の✕で閉じられます

------
https://chatgpt.com/codex/tasks/task_e_684a5b410fc0832c9e06d03a7612d410