### PR TITLE
グラフのホバーに追従する点を追加

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -59,6 +59,8 @@ body {
 .sparkline-container {
   /* カード内で 8px の余白をとる */
   padding: 8px;
+  /* ツールチップ配置の基準とするため相対位置に */
+  position: relative;
   /* 親要素の幅に合わせつつ padding を含めた幅計算にする */
   width: 100%;
   box-sizing: border-box;
@@ -86,6 +88,13 @@ body {
   padding: 2px 4px;
   pointer-events: none;
   white-space: nowrap;
+}
+
+/* ホバー位置を示す点 */
+.sparkline-dot {
+  fill: #f87171; /* 赤系の色 */
+  stroke: #fff;
+  stroke-width: 1px;
 }
 
 /* カードを閉じるためのバツボタン */

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -61,11 +61,14 @@ function Sparkline({ history }) {
   const handleMove = e => {
     if (!containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
+    // マウス位置からコンテナ左端を引いた値をX座標とする
     const x = e.clientX - rect.left + containerRef.current.scrollLeft;
     const step = size.w / (history.length - 1);
     const idx = Math.round(x / step);
     if (idx >= 0 && idx < history.length) {
-      setHoverInfo({ index: idx, x });
+      const value = history[idx];
+      const y = size.h - ((value - min) / range) * size.h;
+      setHoverInfo({ index: idx, x, y });
     } else {
       setHoverInfo(null);
     }
@@ -129,7 +132,14 @@ function Sparkline({ history }) {
       y: size.h - 2,
       fontSize: '10',
       fill: '#555'
-    }, '時間')
+    }, '時間'),
+    // ホバー中の位置に点を表示
+    hoverInfo && React.createElement('circle', {
+      cx: hoverInfo.x,
+      cy: hoverInfo.y,
+      r: 4,
+      className: 'sparkline-dot'
+    })
     ),
     hoverInfo && React.createElement(
       'div',


### PR DESCRIPTION
## 変更点
- スパークラインのホバー処理を更新し、マウス位置に対応した円を描画
- ツールチップ表示位置の基準を取るため `.sparkline-container` を `position: relative` に変更
- ホバー中の点用スタイル `.sparkline-dot` を追加

## テスト
- `npm install` を実行して依存関係をインストール
- `npm test` を実行し、既存の2件のテストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_684a65ca9ee0832cbf0e3a26873819dc