### PR TITLE
スパークライン表示を改善

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -95,6 +95,8 @@ body {
   fill: #f87171; /* 赤系の色 */
   stroke: #fff;
   stroke-width: 1px;
+  /* ドットの移動を滑らかにする */
+  transition: transform 0.1s linear;
 }
 
 /* カードを閉じるためのバツボタン */

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -135,10 +135,10 @@ function Sparkline({ history }) {
     }, '時間'),
     // ホバー中の位置に点を表示
     hoverInfo && React.createElement('circle', {
-      cx: hoverInfo.x,
-      cy: hoverInfo.y,
+      // cx,cy の代わりに transform を利用して位置を調整
       r: 4,
-      className: 'sparkline-dot'
+      className: 'sparkline-dot',
+      style: { transform: `translate(${hoverInfo.x}px, ${hoverInfo.y}px)` }
     })
     ),
     hoverInfo && React.createElement(


### PR DESCRIPTION
## 変更内容
- `.sparkline-dot` に移動アニメーションを追加
- React版ゲーム画面のスパークラインでドット位置を `transform` で指定
- `npm install` 実行後、テストが成功することを確認

## 使い方
ゲーム画面を開くと経済指標が自動更新されます。各指標をタップすると詳細カードが開き、履歴グラフ上にマウスを乗せると赤いドットが滑らかに移動して値を表示します。

------
https://chatgpt.com/codex/tasks/task_e_684a695f3e6c832c8c1c3b8d57edebfd