### PR TITLE
IndicatorCardの統計表示追加

### DIFF
--- a/public/components/IndicatorCard.js
+++ b/public/components/IndicatorCard.js
@@ -11,6 +11,17 @@
   }
 
   function IndicatorCard(props) {
+  // -----------------------------
+  // history から統計値を計算する
+  // -----------------------------
+  const max = Math.max(...props.history);
+  const min = Math.min(...props.history);
+  const diff =
+    props.history.length >= 2
+      ? props.history[props.history.length - 1] -
+        props.history[props.history.length - 2]
+      : 0;
+
   return React.createElement(
     'div',
     { className: 'fixed inset-0 flex items-center justify-center z-40' },
@@ -48,6 +59,28 @@
           'p',
           { className: 'usage-note flex-1 text-sm text-gray-600 ml-2' },
           props.desc
+        )
+      ),
+      // スパークライン下部に統計値を表示
+      React.createElement(
+        'div',
+        { className: 'text-xs ml-2 mt-1 space-y-1' },
+        React.createElement(
+          'p',
+          { className: 'max-value' },
+          `最高値: ${max.toFixed(1)}`
+        ),
+        React.createElement(
+          'p',
+          { className: 'min-value' },
+          `最低値: ${min.toFixed(1)}`
+        ),
+        React.createElement(
+          'p',
+          { className: 'diff-value' },
+          diff > 0
+            ? `前回比: +${diff.toFixed(1)}`
+            : `前回比: ${diff.toFixed(1)}`
         )
       )
     )

--- a/tests/sparkline.test.js
+++ b/tests/sparkline.test.js
@@ -33,5 +33,13 @@ describe('IndicatorCard Sparkline', () => {
     // 新たに追加された使い方メモの要素が存在するか確認
     const note = container.querySelector('.usage-note');
     expect(note).not.toBeNull();
+
+    // 追加された統計値要素が存在するか確認
+    const maxEl = container.querySelector('.max-value');
+    const minEl = container.querySelector('.min-value');
+    const diffEl = container.querySelector('.diff-value');
+    expect(maxEl).not.toBeNull();
+    expect(minEl).not.toBeNull();
+    expect(diffEl).not.toBeNull();
   });
 });


### PR DESCRIPTION
## 概要
IndicatorCard コンポーネントに履歴データから計算した統計値を表示する機能を追加しました。これに合わせてテストも更新しています。

## 変更点
- history から最高値・最低値・前回比を算出し表示
- Sparkline 下部に統計値を並べる要素を追加
- テスト `sparkline.test.js` に新しい要素の存在チェックを追加

## 使い方
ゲーム画面で指標を開いた際、グラフの下に最高値・最低値・前回比が日本語で表示されます。履歴データが 2 件以上あれば前回比も計算されます。

------
https://chatgpt.com/codex/tasks/task_e_684b628ec598832ca6a468e53a43835b