### PR TITLE
Reactのactインポート修正

### DIFF
--- a/tests/sparkline.test.js
+++ b/tests/sparkline.test.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom/client');
-const { act } = require('react-dom/test-utils');
+// React の act 関数を直接インポートする
+const { act } = require('react');
 
 // jsdom 環境でIndicatorCardを描画し、スパークライン要素が存在するか確認
 

--- a/tests/start_screen_react.test.js
+++ b/tests/start_screen_react.test.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const React = require('react');
 const ReactDOM = require('react-dom/client');
-const { act } = require('react-dom/test-utils');
+// React の act 関数を直接インポートする
+const { act } = require('react');
 
 describe('StartScreen React', () => {
   test('画面クリックで game_screen_react.html に遷移しようとする', () => {


### PR DESCRIPTION
## 変更内容
- `tests/start_screen_react.test.js` と `tests/sparkline.test.js` で `ReactDOMTestUtils` ではなく `react` から `act` を読み込むよう修正
- テストを実行し、非推奨警告が表示されなくなったことを確認

## 動作確認方法
1. `npm install`
2. `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b66a95994832ca1c8fd0d6c7098b7