### PR TITLE
グラフ統計と数値表示を改善

### DIFF
--- a/public/components/IndicatorCard.js
+++ b/public/components/IndicatorCard.js
@@ -21,6 +21,8 @@
       ? props.history[props.history.length - 1] -
         props.history[props.history.length - 2]
       : 0;
+  const diffSign = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
+  const diffColor = diff > 0 ? 'text-lime-500' : diff < 0 ? 'text-red-500' : 'text-gray-500';
 
   return React.createElement(
     'div',
@@ -45,7 +47,8 @@
       React.createElement(
         'p',
         { className: 'text-3xl font-mono text-center' },
-        `${props.value.toFixed(1)}${props.unit}`
+        `${props.value.toFixed(1)}${props.unit}`,
+        React.createElement('span', { className: `ml-2 text-xl ${diffColor}` }, diffSign)
       ),
       React.createElement(
         'div',
@@ -77,10 +80,8 @@
         ),
         React.createElement(
           'p',
-          { className: 'diff-value' },
-          diff > 0
-            ? `前回比: +${diff.toFixed(1)}`
-            : `前回比: ${diff.toFixed(1)}`
+          { className: `diff-value ${diffColor}` },
+          `前回比: ${diffSign}`
         )
       )
     )

--- a/public/components/Sparkline.js
+++ b/public/components/Sparkline.js
@@ -75,8 +75,6 @@
       React.createElement('line', { x1: 0, y1: size.h, x2: size.w, y2: size.h, stroke: '#ccc', strokeWidth: 1 }),
       React.createElement('line', { x1: 0, y1: 0, x2: 0, y2: size.h, stroke: '#ccc', strokeWidth: 1 }),
       React.createElement('polyline', { points, fill: 'none', stroke: '#3b82f6', strokeWidth: 2 }),
-      React.createElement('text', { x: 2, y: 10, fontSize: '10', fill: '#555' }, max.toFixed(1)),
-      React.createElement('text', { x: 2, y: size.h - 2, fontSize: '10', fill: '#555' }, min.toFixed(1)),
       React.createElement('text', { x: size.w - 24, y: size.h - 2, fontSize: '10', fill: '#555' }, '時間'),
       hoverInfo && React.createElement('circle', { r: 4, className: 'sparkline-dot', style: { transform: `translate(${hoverInfo.x}px, ${hoverInfo.y}px)` } })
     ),
@@ -84,6 +82,12 @@
       'div',
       { className: 'sparkline-tooltip', style: { left: `${hoverInfo.x}px` } },
       history[hoverInfo.index].toFixed(1)
+    ),
+    React.createElement(
+      'div',
+      { className: 'sparkline-stats flex justify-between text-xs text-gray-500 mt-1' },
+      React.createElement('span', { className: 'max-value' }, `最高: ${max.toFixed(1)}`),
+      React.createElement('span', { className: 'min-value' }, `最低: ${min.toFixed(1)}`)
     )
   );
   }


### PR DESCRIPTION
## 変更内容
- Sparkline コンポーネントで最高値・最低値をグラフ下に表示
- IndicatorCard で前回比を赤/緑表示し、値の横にも差分を追加

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b6719f918832ca57edf812e30aa07