### PR TITLE
経済指数カードのデザインサンプルを追加

### DIFF
--- a/public/economic_index_card.css
+++ b/public/economic_index_card.css
@@ -1,0 +1,42 @@
+/* 経済指数カード用のスタイル */
+
+/* ページ全体のフォントを設定 */
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+}
+
+/* カード外枠 */
+.card-container {
+    background-color: #ffffff;             /* 白背景 */
+    border-radius: 0.75rem;                /* 角を丸く */
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* ほんのり影をつける */
+    width: 18rem;                          /* 幅は約 18rem */
+    padding: 1rem;                         /* 内側余白 */
+}
+
+/* タイトル部分。コンサルを意識した落ち着いた緑色 */
+.card-title {
+    background-color: #0d9488;   /* teal-700 相当の色 */
+    color: #ffffff;              /* 文字色は白 */
+    padding: 0.25rem 0.5rem;     /* ちょっと余白をとる */
+    border-radius: 0.375rem;     /* 角丸 */
+    font-size: 0.875rem;         /* text-sm 程度 */
+    font-weight: bold;           /* 太字 */
+    margin-bottom: 0.5rem;       /* タイトル下の余白 */
+    text-align: center;          /* 中央寄せ */
+}
+
+/* 値を表示する部分。大きめのフォントで中央に配置 */
+.card-value {
+    font-size: 2rem;             /* text-3xl 程度 */
+    font-family: 'Zen Maru Gothic', sans-serif; /* 柔らかい日本語フォント */
+    text-align: center;          /* 中央寄せ */
+    color: #0d9488;              /* タイトルと同系色 */
+}
+
+/* 説明文用のスタイル */
+.card-desc {
+    font-size: 0.75rem;          /* text-xs 程度 */
+    color: #555555;              /* 少し薄い文字色 */
+    margin-top: 0.5rem;          /* 上側に余白 */
+}

--- a/public/economic_index_card.html
+++ b/public/economic_index_card.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>経済指数カード デザイン案</title>
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- React と ReactDOM を読み込み -->
+  <script src="libs/react.development.js"></script>
+  <script src="libs/react-dom.development.js"></script>
+  <!-- スパークラインコンポーネント -->
+  <script src="components/Sparkline.js"></script>
+  <!-- 経済カード用コンポーネント -->
+  <script src="economy_index_card.js"></script>
+  <!-- 専用のスタイルシート -->
+  <link rel="stylesheet" href="economic_index_card.css" />
+</head>
+<body class="bg-gray-100 flex items-center justify-center min-h-screen">
+  <!-- React でカードを表示するエリア -->
+  <div id="root"></div>
+  <script>
+    // サンプルデータを用意
+    const history = [100, 101, 102, 103, 105, 104, 106];
+    // 経済指数カードを描画
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      React.createElement(EconomyIndexCard, {
+        title: 'CPI（消費者物価指数）',
+        value: history[history.length - 1],
+        unit: '',
+        history,
+        desc: '物価の動向を示す代表的な指標です。'
+      })
+    );
+  </script>
+</body>
+</html>

--- a/public/economy_index_card.js
+++ b/public/economy_index_card.js
@@ -1,0 +1,45 @@
+(function () {
+  // React の createElement を取得
+  const { createElement } = React;
+  // Sparkline コンポーネントはブラウザではグローバル変数として利用
+  let Sparkline = window.Sparkline;
+
+  /**
+   * 経済指数カードを表示するコンポーネント
+   * @param {object} props
+   * @param {string} props.title  - 指標名
+   * @param {number} props.value  - 現在値
+   * @param {string} props.unit   - 単位（例: %, 円）
+   * @param {number[]} props.history - 履歴データ
+   * @param {string} props.desc   - 指標の説明
+   */
+  function EconomyIndexCard(props) {
+    return createElement(
+      'div',
+      { className: 'card-container' },
+      // タイトル部分
+      createElement('div', { className: 'card-title' }, props.title),
+      // 現在値を大きく表示
+      createElement(
+        'p',
+        { className: 'card-value' },
+        props.value.toFixed(1) + (props.unit || '')
+      ),
+      // スパークラインは履歴がある場合のみ描画
+      props.history &&
+        createElement('div', { className: 'mt-2' },
+          createElement(Sparkline, { history: props.history })
+        ),
+      // 補足説明
+      createElement('p', { className: 'card-desc' }, props.desc)
+    );
+  }
+
+  // エクスポート設定
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { EconomyIndexCard };
+  }
+  if (typeof window !== 'undefined') {
+    window.EconomyIndexCard = EconomyIndexCard;
+  }
+})();


### PR DESCRIPTION
## 概要
- 経済指数カードのサンプルファイルを新規作成
- CSS でシンプルなカードスタイルを用意
- React コンポーネント `EconomyIndexCard` を追加
- サンプル表示用の HTML を追加

## 使い方
`public/economic_index_card.html` をブラウザで開くと、サンプルの経済指数カードが表示されます。指標名・数値・スパークラインと説明をまとめて確認できます。

------
https://chatgpt.com/codex/tasks/task_e_684b697001dc832c9e4e663f7b68fbb0