### PR TITLE
指標カードに次回予想を表示

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -48,6 +48,17 @@
   const prevStatsRef = useRef(stats);
   const [diffStats, setDiffStats] = useState({ cpi: 0, unemp: 0, gdp: 0, rate: 0 });
 
+  // -----------------------------
+  // 現在の指標と需給・金利から次ターンの指標を計算する補助関数
+  // -----------------------------
+  const calcNextStats = () => {
+    // updateEconomy 関数が利用可能か確認し、無ければ現在値を返す
+    if (typeof updateEconomy === 'function') {
+      return updateEconomy(stats, { demand, supply, policyRate });
+    }
+    return stats;
+  };
+
   const [demand, setDemand] = useState(5);
   const [supply, setSupply] = useState(5);
   const [policyRate, setPolicyRate] = useState(0.0);
@@ -267,6 +278,8 @@
           unit: indicatorInfo[activeIndicator].unit,
           desc: indicatorInfo[activeIndicator].desc,
           history: historyMap[activeIndicator],
+          // calcNextStats() で求めた次ターンの値を渡す
+          nextValue: calcNextStats()[activeIndicator],
           onClose: () => setActiveIndicator(null)
         })
       : null,

--- a/public/components/IndicatorCard.js
+++ b/public/components/IndicatorCard.js
@@ -85,7 +85,15 @@
           'p',
           { className: `diff-value ${diffColor}` },
           `前回比: ${diffSign}`
-        )
+        ),
+        // 予測値が渡されていれば表示
+        props.nextValue !== undefined
+          ? React.createElement(
+              'p',
+              { className: 'next-value text-blue-600' },
+              `次回予想: ${props.nextValue.toFixed(1)}${props.unit}`
+            )
+          : null
       )
     )
   );

--- a/tests/sparkline.test.js
+++ b/tests/sparkline.test.js
@@ -21,6 +21,8 @@ describe('IndicatorCard Sparkline', () => {
           unit: '',
           desc: 'desc',
           history: [1, 2, 3],
+          // 予測値を追加
+          nextValue: 2,
           onClose: () => {}
         })
       );
@@ -42,5 +44,9 @@ describe('IndicatorCard Sparkline', () => {
     expect(maxEl).not.toBeNull();
     expect(minEl).not.toBeNull();
     expect(diffEl).not.toBeNull();
+
+    // 予測値要素が存在するか確認
+    const nextEl = container.querySelector('.next-value');
+    expect(nextEl).not.toBeNull();
   });
 });


### PR DESCRIPTION
## 変更内容
- updateEconomy を利用し GameScreen から次ターン値を計算
- IndicatorCard に `nextValue` プロパティを追加し予測値を表示
- GameScreen から IndicatorCard へ `nextValue` を渡すよう修正
- テストを更新し予測値要素の存在を確認

## 使い方
ゲーム画面で経済指標のカードを開くと、現在値に加えて次回予想値が表示されます。

------
https://chatgpt.com/codex/tasks/task_e_684bb03ba524832c803d01ed9ca1e8f7