### PR TITLE
経済指数カード機能の追加

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -21,6 +21,24 @@ body {
     transform: translateX(0);
 }
 
+/* ドロワー内の経済指数リスト */
+#indexList li {
+    cursor: pointer;
+    padding: 0.5rem;
+    border-bottom: 1px solid #eee;
+    text-align: left;
+}
+
+/* 詳細カードのスタイル */
+#indexDetailCard {
+    margin: 1rem;
+    padding: 1rem;
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    border-radius: 0.5rem;
+    text-align: left;
+}
+
 /* ステータスバーなど共通要素の余白調整 */
 #statusBar div {
     padding: 0 0.5rem;

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -36,10 +36,13 @@
     </div>
 
     <!-- 詳細情報を表示するドロワー -->
-    <div id="drawer" class="fixed top-0 right-0 h-full w-64 bg-white shadow-lg transform translate-x-full transition-transform">
+    <div id="drawer" class="fixed top-0 right-0 h-full w-64 bg-white shadow-lg transform translate-x-full transition-transform overflow-y-auto">
         <button id="closeDrawer" class="p-2">閉じる</button>
-        <h2 class="text-lg p-2">詳細情報</h2>
-        <p class="p-2">ここに詳細情報を表示します。</p>
+        <h2 class="text-lg p-2">経済指数</h2>
+        <!-- 経済指数の一覧を表示する -->
+        <ul id="indexList" class="p-2 border-t"></ul>
+        <!-- 選択した指数の説明を表示するカード -->
+        <div id="indexDetailCard" class="p-2"></div>
     </div>
 </body>
 </html>

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -3,11 +3,49 @@
 // 日本語コメントで処理内容を説明します
 // =========================================
 
-window.addEventListener('DOMContentLoaded', function() {
+function initializeGameScreen() {
     // ドロワー関連の要素を取得
     var drawer = document.getElementById('drawer');
     var openButton = document.getElementById('drawerButton');
     var closeButton = document.getElementById('closeDrawer');
+
+    // 経済指数のリストと詳細表示用カードを取得
+    var indexList = document.getElementById('indexList');
+    var detailCard = document.getElementById('indexDetailCard');
+
+    // 経済指数のデータ構造を定義
+    var economicIndices = [
+        {
+            name: 'GDP成長率',
+            impact: '国内総生産の増減を示す指標で、経済全体の勢いを把握できます。'
+        },
+        {
+            name: '失業率',
+            impact: '労働力人口に対する失業者の割合で、景気の良し悪しを反映します。'
+        },
+        {
+            name: 'インフレ率',
+            impact: '物価上昇率を示し、購買力への影響や金融政策の判断材料となります。'
+        }
+    ];
+
+    // テストから参照できるようにグローバルへ公開
+    window.economicIndices = economicIndices;
+
+    // リストを生成してドロワーに追加
+    if (indexList) {
+        economicIndices.forEach(function(item, idx) {
+            var li = document.createElement('li');
+            li.textContent = item.name;
+            // リスト項目をタップしたときの処理
+            li.addEventListener('click', function() {
+                // クリックされた指数の説明をカードに表示
+                detailCard.innerHTML = '<h3 class="font-bold mb-2">' + item.name + '</h3>' +
+                    '<p>' + item.impact + '</p>';
+            });
+            indexList.appendChild(li);
+        });
+    }
 
     // ドロワーを開閉する関数
     function toggleDrawer() {
@@ -25,4 +63,10 @@ window.addEventListener('DOMContentLoaded', function() {
             drawer.classList.remove('open');
         });
     }
-});
+}
+
+// DOMContentLoaded 時に実行
+window.addEventListener('DOMContentLoaded', initializeGameScreen);
+
+// テストから直接呼び出せるよう公開
+window.initializeGameScreen = initializeGameScreen;

--- a/tests/game_screen.test.js
+++ b/tests/game_screen.test.js
@@ -1,0 +1,38 @@
+// public/game_screen.js の動作確認テスト
+
+// JSDOM環境で実行
+
+describe('public/game_screen.js', () => {
+  beforeEach(() => {
+    // ドロワー関連の要素を準備
+    document.body.innerHTML = `
+      <div id="drawer">
+        <button id="drawerButton"></button>
+        <button id="closeDrawer"></button>
+        <ul id="indexList"></ul>
+        <div id="indexDetailCard"></div>
+      </div>
+    `;
+
+    // モジュールを読み込む
+    jest.isolateModules(() => {
+      require('../public/game_screen.js');
+    });
+
+    // DOMContentLoaded の代わりに直接初期化関数を呼び出す
+    window.initializeGameScreen();
+  });
+
+  test('経済指数リストが生成される', () => {
+    const indexList = document.getElementById('indexList');
+    expect(indexList.children.length).toBe(window.economicIndices.length);
+  });
+
+  test('リスト項目クリックで説明文が表示される', () => {
+    const indexList = document.getElementById('indexList');
+    const firstItem = indexList.children[0];
+    firstItem.click();
+    const detail = document.getElementById('indexDetailCard');
+    expect(detail.textContent).toContain(window.economicIndices[0].impact);
+  });
+});


### PR DESCRIPTION
## 概要
- ドロワーに経済指数リストと詳細カードを追加
- 経済指数データを用意し、タップで説明文を表示
- スタイルを調整し、スマホでも見やすいレイアウトに
- Jest テストを追加し、カード表示の動作を確認

## 使い方
1. `index.html` をブラウザで開く
2. 画面をタップしてゲーム画面へ移動
3. 右上の「メニュー」を押すと経済指数リストが表示
4. 指数名をタップすると、その内容が下部カードに表示されます

## テスト方法
```bash
npm install
npm test
```


------
https://chatgpt.com/codex/tasks/task_e_684c324f97b4832c91241a9b3bcb4f8e