### PR TITLE
ゲーム画面で指数説明カードを表示

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -108,3 +108,9 @@ body {
   font-weight: bold;
   cursor: pointer;
 }
+
+/* 指数詳細カードのボックスは縦スクロール可能にしてスマホでも見やすく */
+.detail-box {
+  max-height: 80vh;
+  overflow-y: auto;
+}

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -29,8 +29,10 @@
   <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->
   <aside id="drawer" class="fixed top-0 left-0 h-full w-64 -translate-x-full transform transition-transform duration-300 bg-white shadow-lg z-40 flex flex-col relative">
-    <nav class="p-4 space-y-4 flex-1">
+    <nav class="p-4 space-y-4 flex-1 overflow-y-auto">
       <button id="statsBtn" class="w-full text-left py-2 px-3 bg-gray-100 rounded">📊 経済指標</button>
+      <!-- 指数のリスト。スクリプトから項目が追加される -->
+      <ul id="indexList" class="mt-2 space-y-1 text-sm"></ul>
       <button class="w-full text-left py-2 px-3 bg-gray-100 rounded">🗂 クライアント情報</button>
       <button class="w-full text-left py-2 px-3 bg-gray-100 rounded">📜 履歴</button>
     </nav>
@@ -39,7 +41,7 @@
   <!-- モーダル -->
   <div id="statsModal" class="fixed inset-0 hidden items-center justify-center z-50">
     <div id="modalBg" class="absolute inset-0 bg-black/60"></div>
-    <div class="relative bg-white rounded shadow-lg w-11/12 max-w-md p-6 space-y-4 z-10">
+    <div class="detail-box relative bg-white rounded shadow-lg w-11/12 max-w-md p-6 space-y-4 z-10">
       <button id="closeModal" class="absolute top-2 right-3 text-xl">×</button>
       <h2 class="text-xl font-bold mb-2">経済指標</h2>
       <ul class="space-y-1 font-mono list-none">
@@ -48,6 +50,16 @@
         <li>GDP成長率: <span id="gdp">1.8</span>%</li>
         <li>政策金利: <span id="rate">1.2</span>%</li>
       </ul>
+    </div>
+  </div>
+
+  <!-- 指数の説明カード -->
+  <div id="indexDetailCard" class="fixed inset-0 hidden items-center justify-center z-50">
+    <div id="detailBg" class="absolute inset-0 bg-black/60"></div>
+    <div class="relative bg-white rounded shadow-lg w-11/12 max-w-md p-6 space-y-4 z-10">
+      <button id="closeDetail" class="absolute top-2 right-3 text-xl">×</button>
+      <h3 id="detailTitle" class="text-lg font-bold"></h3>
+      <p id="detailText" class="text-sm whitespace-pre-line"></p>
     </div>
   </div>
   <!-- ゲーム用スクリプトを読み込み -->

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -13,18 +13,71 @@ window.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('statsModal');
   const modalBg = document.getElementById('modalBg');
   const closeBtn = document.getElementById('closeModal');
+  const listEl = document.getElementById('indexList');
+  const detailCard = document.getElementById('indexDetailCard');
+  const detailBg = document.getElementById('detailBg');
+  const closeDetail = document.getElementById('closeDetail');
+  const detailTitle = document.getElementById('detailTitle');
+  const detailText = document.getElementById('detailText');
+
+  // --- 経済指数データ ------------------------------
+  // 各指数の名前と経済への影響をまとめる
+  const indexData = {
+    cpi: {
+      name: '消費者物価指数 (CPI)',
+      impact: '物価の動きを示す代表指標。上昇は購買力を下げ景気を冷やします。'
+    },
+    unemp: {
+      name: '失業率',
+      impact: '働く意欲があるのに職がない人の割合。上昇は所得減少を通じ消費を抑制します。'
+    },
+    gdp: {
+      name: 'GDP成長率',
+      impact: '国全体の生産活動の伸びを表します。高い成長は雇用や投資を後押しします。'
+    },
+    rate: {
+      name: '政策金利',
+      impact: '中央銀行が決める短期金利。引き上げは景気を抑え、引き下げは刺激します。'
+    }
+  };
+
+  // 詳細カードの表示処理
+  function showDetail(key) {
+    detailTitle.textContent = indexData[key].name;
+    detailText.textContent = indexData[key].impact;
+    detailCard.classList.remove('hidden');
+    closeDrawer();
+  }
+
+  function hideDetail() {
+    detailCard.classList.add('hidden');
+  }
+  [detailBg, closeDetail].forEach((el) => {
+    el.addEventListener('click', hideDetail);
+  });
+
+  // リストに項目を表示
+  Object.keys(indexData).forEach((key) => {
+    const li = document.createElement('li');
+    li.textContent = indexData[key].name;
+    li.className = 'p-2 bg-gray-50 rounded cursor-pointer hover:bg-gray-100';
+    li.addEventListener('click', () => {
+      showDetail(key);
+    });
+    listEl.appendChild(li);
+  });
 
   // --- ドロワー開閉処理 ----------------------------
   // ボタンを押すと、drawer-open クラスの付け外しで表示を切り替える
-  const openDrawer = () => {
+  function openDrawer() {
     drawer.classList.add('drawer-open');
     overlay.classList.add('overlay-show');
-  };
+  }
 
-  const closeDrawer = () => {
+  function closeDrawer() {
     drawer.classList.remove('drawer-open');
     overlay.classList.remove('overlay-show');
-  };
+  }
 
   // ボタンを押すとドロワーを開く
   drawerBtn.addEventListener('click', openDrawer);

--- a/tests/index_detail.test.js
+++ b/tests/index_detail.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+// DOM構築後にスクリプトを読み込んでイベントをテストする
+
+describe('index detail card', () => {
+  test('リストクリックで説明が表示される', () => {
+    // HTMLを読み込み
+    const html = fs.readFileSync(path.join(__dirname, '../public/game_screen.html'), 'utf8');
+    document.documentElement.innerHTML = html;
+
+    // スクリプトを読み込み
+    require('../public/game_screen.js');
+    // DOMContentLoaded を発火させる
+    document.dispatchEvent(new Event('DOMContentLoaded', { bubbles: true }));
+
+    // リスト要素が生成されているか確認
+    const list = document.getElementById('indexList');
+    expect(list.children.length).toBeGreaterThan(0);
+
+    const first = list.children[0];
+    first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const card = document.getElementById('indexDetailCard');
+    expect(card.classList.contains('hidden')).toBe(false);
+
+    const title = document.getElementById('detailTitle');
+    expect(title.textContent.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 変更内容
- ドロワーに経済指数リストを追加し、クリックで詳細を開くようにしました
- 指数説明用モーダル`indexDetailCard`を実装
- `game_screen.js`に指数情報を持たせ、リスト生成とカード表示処理を記述
- スタイルを調整しスマホでも読みやすくしました
- DOM操作を確認するテスト`index_detail.test.js`を追加

## 使い方
ゲーム画面で左上のメニューボタンを押すと、指数一覧が表示されます。項目をタップすると簡単な解説カードが開きます。

------
https://chatgpt.com/codex/tasks/task_e_684c35ae9358832c82992399cfafe5b5