### PR TITLE
IndicatorDetailModal with impact list

### DIFF
--- a/public/components/GameImpactList.js
+++ b/public/components/GameImpactList.js
@@ -1,0 +1,28 @@
+(function () {
+  function GameImpactList({ impact }) {
+    if (!impact || impact.length === 0) return null;
+    return React.createElement(
+      'ul',
+      { className: 'space-y-1' },
+      impact.map((item, idx) =>
+        React.createElement(
+          'li',
+          { key: idx, className: 'impact-item flex items-center gap-2 text-sm' },
+          React.createElement(
+            'span',
+            { className: item.sign === 'positive' ? 'text-green-500' : 'text-red-500' },
+            item.sign === 'positive' ? '▲' : '▼'
+          ),
+          React.createElement('span', null, item.title)
+        )
+      )
+    );
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { GameImpactList };
+  }
+  if (typeof window !== 'undefined') {
+    window.GameImpactList = GameImpactList;
+  }
+})();

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -1,13 +1,13 @@
 // GameScreen コンポーネント
 // ゲーム画面全体を管理するメインコンポーネント
 (function () {
-  let Sparkline, IndicatorCard;
+  let Sparkline, IndicatorDetailModal;
   if (typeof require !== 'undefined') {
     ({ Sparkline } = require('./Sparkline.js'));
-    ({ IndicatorCard } = require('./IndicatorCard.js'));
+    ({ IndicatorDetailModal } = require('./IndicatorDetailModal.js'));
   } else if (typeof window !== 'undefined') {
     Sparkline = window.Sparkline;
-    IndicatorCard = window.IndicatorCard;
+    IndicatorDetailModal = window.IndicatorDetailModal;
   }
 
   const { useState, useEffect, useRef } = React;
@@ -320,11 +320,10 @@
       )
     ),
     activeIndicator
-      ? React.createElement(IndicatorCard, {
+      ? React.createElement(IndicatorDetailModal, {
           title: indicatorInfo[activeIndicator].label,
           value: stats[activeIndicator],
           unit: indicatorInfo[activeIndicator].unit,
-          desc: indicatorInfo[activeIndicator].desc,
           history: historyMap[activeIndicator],
           // calcNextStats() で求めた次ターンの値を渡す
           nextValue: calcNextStats()[activeIndicator],
@@ -337,7 +336,7 @@
               : null,
           correlWithLabel:
             indicatorInfo[indicatorInfo[activeIndicator].correlWith]?.label,
-          impactDesc: indicatorInfo[activeIndicator].impactDesc,
+          impact: indicatorInfo[activeIndicator].impact,
           onClose: () => setActiveIndicator(null)
         })
       : null,

--- a/public/components/IndicatorDetailModal.js
+++ b/public/components/IndicatorDetailModal.js
@@ -1,0 +1,72 @@
+(function () {
+  let Sparkline, GameImpactList;
+  if (typeof require !== 'undefined') {
+    ({ Sparkline } = require('./Sparkline.js'));
+    ({ GameImpactList } = require('./GameImpactList.js'));
+  } else if (typeof window !== 'undefined') {
+    Sparkline = window.Sparkline;
+    GameImpactList = window.GameImpactList;
+  }
+
+  function IndicatorDetailModal(props) {
+    // 前回との差分を計算
+    const diff =
+      props.history && props.history.length >= 2
+        ? props.history[props.history.length - 1] -
+          props.history[props.history.length - 2]
+        : 0;
+    const diffSign = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
+    const diffColor = diff > 0 ? 'text-green-500' : diff < 0 ? 'text-red-500' : 'text-gray-500';
+
+    return React.createElement(
+      'div',
+      { className: 'fixed inset-0 flex items-center justify-center z-50' },
+      React.createElement('div', {
+        className: 'absolute inset-0 bg-black/40',
+        onClick: props.onClose,
+      }),
+      React.createElement(
+        'div',
+        {
+          className:
+            'relative bg-white rounded-xl shadow-lg w-11/12 max-w-3xl py-6 px-8 flex sm:flex-col md:flex-row gap-4 z-10',
+        },
+        React.createElement(
+          'button',
+          { onClick: props.onClose, className: 'absolute top-2 right-3 text-xl' },
+          '×'
+        ),
+        React.createElement(
+          'div',
+          { className: 'md:w-3/5 w-full' },
+          React.createElement(Sparkline, { history: props.history, height: 180 })
+        ),
+        React.createElement(
+          'div',
+          { className: 'md:w-2/5 w-full flex flex-col space-y-4' },
+          React.createElement(
+            'h2',
+            { className: 'text-2xl font-bold' },
+            `${props.value.toFixed(1)}${props.unit}`,
+            React.createElement('span', { className: `ml-2 text-xl ${diffColor}` }, diffSign)
+          ),
+          props.correlation !== null && props.correlWithLabel
+            ? React.createElement(
+                'div',
+                { className: 'bg-gray-100 rounded-xl p-3 text-sm correlation-block' },
+                `${props.correlWithLabel}との相関: ${props.correlation.toFixed(2)}`
+              )
+            : null,
+          props.impact && React.createElement(GameImpactList, { impact: props.impact })
+        )
+      )
+    );
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { IndicatorDetailModal };
+  }
+  if (typeof window !== 'undefined') {
+    window.IndicatorDetailModal = IndicatorDetailModal;
+  }
+})();

--- a/public/components/Sparkline.js
+++ b/public/components/Sparkline.js
@@ -3,30 +3,34 @@
 (function () {
   const { useState, useEffect, useRef } = React;
 
-  function Sparkline({ history }) {
+  // 高さを props.height で指定できるようにする
+  function Sparkline({ history, height }) {
   // 履歴が無ければ何も描画しない
   if (!history || history.length === 0) return null;
 
   // 親要素を参照してサイズを決定する
   const containerRef = useRef(null);
   // 描画サイズとマウスホバー位置を状態として保持
-  const [size, setSize] = useState({ w: 300, h: 150 });
+  // 初期サイズ。高さは引数から、なければ150にする
+  const [size, setSize] = useState({ w: 300, h: height || 150 });
   const [hoverInfo, setHoverInfo] = useState(null);
 
   useEffect(() => {
     // コンポーネント表示後に幅を取得して高さと合わせる
+    // 親要素の幅からサイズを計算
     const update = () => {
       if (containerRef.current) {
         const base = containerRef.current.clientWidth;
         const w = base;
-        const h = base / 3;
+        // 指定があればその高さを、なければ幅の1/3を使う
+        const h = height || base / 3;
         setSize({ w, h });
       }
     };
     update();
     window.addEventListener('resize', update);
     return () => window.removeEventListener('resize', update);
-  }, []);
+  }, [height]);
 
   // 表示範囲を決定するための最小値・最大値
   const min = Math.min(...history);
@@ -63,7 +67,13 @@
   // 実際の描画要素を返す
   return React.createElement(
     'div',
-    { ref: containerRef, className: 'sparkline-container', onPointerMove: handleMove, onPointerLeave: handleLeave },
+    {
+      ref: containerRef,
+      className: 'sparkline-container',
+      onPointerMove: handleMove,
+      onPointerLeave: handleLeave,
+      style: { height: `${size.h}px` }
+    },
     React.createElement(
       'svg',
       {

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -15,7 +15,8 @@
   <link rel="stylesheet" href="game_screen.css" />
   <!-- React用コンポーネントを読み込み -->
   <script defer src="components/Sparkline.js"></script>
-  <script defer src="components/IndicatorCard.js"></script>
+  <script defer src="components/GameImpactList.js"></script>
+  <script defer src="components/IndicatorDetailModal.js"></script>
   <script defer src="components/GameScreen.js"></script>
   <!-- React版スクリプト読み込み -->
   <script defer src="game_screen_react.js"></script>

--- a/tests/correlation.test.js
+++ b/tests/correlation.test.js
@@ -2,38 +2,37 @@ const React = require('react');
 const ReactDOM = require('react-dom/client');
 const { act } = require('react');
 
-// IndicatorCard に相関値と影響説明が表示されるか確認
+// IndicatorDetailModal に相関ブロックが表示されるか確認
 
-describe('IndicatorCard correlation and impact', () => {
+describe('IndicatorDetailModal correlation block', () => {
   test('相関値と影響説明が表示される', () => {
     document.body.innerHTML = '<div id="root"></div>';
     global.React = React;
     global.ReactDOM = ReactDOM;
-    const { IndicatorCard } = require('../public/components/IndicatorCard.js');
+    const { IndicatorDetailModal } = require('../public/components/IndicatorDetailModal.js');
 
     const container = document.createElement('div');
     act(() => {
       ReactDOM.createRoot(container).render(
-        React.createElement(IndicatorCard, {
+        React.createElement(IndicatorDetailModal, {
           title: 'test',
           value: 1,
           unit: '',
-          desc: 'desc',
           history: [1, 2, 3],
           correlation: 0.8,
           correlWithLabel: '政策金利',
-          impactDesc: '金利変更の影響を受けます。',
+          impact: [{ title: '政策変更', sign: 'positive' }],
           onClose: () => {}
         })
       );
     });
 
-    const corrEl = container.querySelector('.correlation');
+    const corrEl = container.querySelector('.correlation-block');
     expect(corrEl).not.toBeNull();
     expect(corrEl.textContent).toContain('0.80');
 
-    const impactEl = container.querySelector('.impact-desc');
+    const impactEl = container.querySelector('.impact-item');
     expect(impactEl).not.toBeNull();
-    expect(impactEl.textContent).toContain('影響');
+    expect(impactEl.textContent).toContain('政策変更');
   });
 });

--- a/tests/sparkline.test.js
+++ b/tests/sparkline.test.js
@@ -3,23 +3,22 @@ const ReactDOM = require('react-dom/client');
 // React の act 関数を直接インポートする
 const { act } = require('react');
 
-// jsdom 環境でIndicatorCardを描画し、スパークライン要素が存在するか確認
+// jsdom 環境でIndicatorDetailModalを描画し、スパークライン要素が存在するか確認
 
-describe('IndicatorCard Sparkline', () => {
+describe('IndicatorDetailModal Sparkline', () => {
   test('スパークラインが描画される', () => {
     document.body.innerHTML = '<div id="root"></div>';
     global.React = React;
     global.ReactDOM = ReactDOM;
-    const { IndicatorCard } = require('../public/components/IndicatorCard.js');
+    const { IndicatorDetailModal } = require('../public/components/IndicatorDetailModal.js');
 
     const container = document.createElement('div');
     act(() => {
       ReactDOM.createRoot(container).render(
-        React.createElement(IndicatorCard, {
+        React.createElement(IndicatorDetailModal, {
           title: 'test',
           value: 1,
           unit: '',
-          desc: 'desc',
           history: [1, 2, 3],
           // 予測値を追加
           nextValue: 2,
@@ -33,20 +32,8 @@ describe('IndicatorCard Sparkline', () => {
     const poly = svg.querySelector('polyline');
     expect(poly).not.toBeNull();
 
-    // 新たに追加された使い方メモの要素が存在するか確認
-    const note = container.querySelector('.usage-note');
-    expect(note).not.toBeNull();
-
-    // 追加された統計値要素が存在するか確認
-    const maxEl = container.querySelector('.max-value');
-    const minEl = container.querySelector('.min-value');
-    const diffEl = container.querySelector('.diff-value');
-    expect(maxEl).not.toBeNull();
-    expect(minEl).not.toBeNull();
-    expect(diffEl).not.toBeNull();
-
-    // 予測値要素が存在するか確認
-    const nextEl = container.querySelector('.next-value');
-    expect(nextEl).not.toBeNull();
+    // 相関ブロックが表示されないことを確認（未指定）
+    const corrEl = container.querySelector('.correlation-block');
+    expect(corrEl).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add `GameImpactList` component for showing positive/negative impacts
- create `IndicatorDetailModal` with 60/40 layout and sparkline chart
- allow `Sparkline` to accept height prop
- use `IndicatorDetailModal` inside GameScreen
- update HTML script tags
- adjust unit tests for new components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d72e395f8832cb2d1411d13f27267