### PR TITLE
Indicator modal redesign

### DIFF
--- a/public/components/GameImpactList.js
+++ b/public/components/GameImpactList.js
@@ -19,7 +19,10 @@
       impact.map((item, idx) =>
         createElement(
           'li',
-          { key: idx, className: 'flex items-center' },
+          {
+            key: idx,
+            className: 'flex items-center hover:scale-105 transition-transform'
+          },
           icon(item.sign),
           createElement('span', null, item.title)
         )

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -372,6 +372,7 @@
           correlLabel:
             indicatorInfo[indicatorInfo[activeIndicator].correlWith]?.label,
           impact: indicatorInfo[activeIndicator].impact,
+          comment: indicatorInfo[activeIndicator].impactDesc,
           onClose: () => setActiveIndicator(null)
         })
       : null,

--- a/public/components/IndicatorDetailModal.js
+++ b/public/components/IndicatorDetailModal.js
@@ -14,11 +14,29 @@
    * IndicatorDetailModal コンポーネント
    * 指標詳細をモーダル表示します
    */
-  function IndicatorDetailModal(props) {
-    const { title, unit, value, history, onClose, correlation, correlLabel, impact } = props;
-    const diff = history && history.length >= 2 ? value - history[history.length - 2] : 0;
+  function CurrentValueDisplay({ value, unit, diff }) {
     const diffStr = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
     const diffColor = diff > 0 ? 'text-green-500' : diff < 0 ? 'text-red-500' : 'text-gray-500';
+    return h(
+      'div',
+      { className: 'text-center' },
+      h('div', { className: 'text-4xl font-bold' }, `${value.toFixed(1)}${unit}`),
+      h('div', { className: `text-sm ${diffColor}` }, `前回比 ${diffStr}`)
+    );
+  }
+
+  function CorrelationBlock({ correlation, label }) {
+    if (correlation === null || !label) return null;
+    return h(
+      'div',
+      { className: 'bg-gray-50 rounded-lg p-2 text-sm text-gray-700' },
+      `${label}との相関: ${correlation.toFixed(2)}`
+    );
+  }
+
+  function IndicatorDetailModal(props) {
+    const { title, unit, value, history, onClose, correlation, correlLabel, impact, comment } = props;
+    const diff = history && history.length >= 2 ? value - history[history.length - 2] : 0;
 
     return h(
       'div',
@@ -29,41 +47,34 @@
         'div',
         {
           className:
-            'relative bg-white rounded-xl shadow-lg w-11/12 max-w-3xl flex sm:flex-col md:flex-row py-6 px-8 space-y-4 md:space-y-0',
+            'consultant-card relative mx-auto max-w-3xl bg-[#f7f5f1] border border-gray-300 shadow-lg rounded-xl px-10 py-8 w-11/12 flex flex-col md:flex-row hover:bg-[#f9f8f6] transition-colors',
         },
-        // 左側スパークライン
-        h(
-          'div',
-          { className: 'md:w-3/5 w-full md:pr-4' },
-          h(Sparkline, { history, height: 180 })
-        ),
-        // 右側情報エリア
-        h(
-          'div',
-          { className: 'md:w-2/5 w-full space-y-4' },
-          // 現在値と前回比
-          h(
-            'h2',
-            { className: `text-3xl font-bold ${diffColor}` },
-            `${value.toFixed(1)}${unit} `,
-            h('span', { className: 'text-xl ml-2' }, `(${diffStr})`)
-          ),
-          // 相関係数
-          correlation !== null && correlLabel
-            ? h(
-                'div',
-                { className: 'bg-gray-100 rounded-xl p-3 text-sm' },
-                `${correlLabel}との相関: ${correlation.toFixed(2)}`
-              )
-            : null,
-          // 影響リスト
-          h(GameImpactList, { impact })
-        ),
         h(
           'button',
           { className: 'absolute top-2 right-3 text-xl', onClick: onClose },
           '×'
-        )
+        ),
+        // 左側スパークライン
+        h(
+          'div',
+          { className: 'flex-1 md:pr-6' },
+          h(Sparkline, { history, height: 180, className: 'flex-1 h-[180px] mt-4' })
+        ),
+        // 右側情報エリア
+        h(
+          'div',
+          { className: 'w-full md:w-2/5 bg-white rounded-xl shadow-inner p-4 space-y-4 mt-4 md:mt-0' },
+          h(CurrentValueDisplay, { value, unit, diff }),
+          h(CorrelationBlock, { correlation, label: correlLabel }),
+          h(GameImpactList, { impact })
+        ),
+        comment
+          ? h(
+              'div',
+              { className: 'border-t mt-6 pt-3 text-sm text-gray-600 italic md:col-span-2' },
+              comment
+            )
+          : null
       )
     );
   }

--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -114,3 +114,25 @@ body {
   max-height: 80vh;
   overflow-y: auto;
 }
+
+/* Consultant Brief Sheet スタイル用 */
+.consultant-card::before {
+  content: '';
+  position: absolute;
+  top: 1rem;
+  bottom: 1rem;
+  left: 0;
+  width: 4px;
+  background: #0cb195;
+}
+
+.consultant-card::after {
+  content: 'INDEX';
+  position: absolute;
+  top: 0;
+  right: 0.5rem;
+  background: rgba(0, 251, 0, 0.9);
+  font-size: 0.75rem;
+  padding: 0 0.25rem;
+  border-radius: 0 0 0 0.25rem;
+}

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -7,12 +7,14 @@
   <!-- TailwindCSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Googleフォントの読み込み -->
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
   <!-- React と ReactDOM をローカルから読み込み -->
   <script src="libs/react.production.min.js"></script>
   <script src="libs/react-dom.production.min.js"></script>
   <!-- 外部CSS（必要なら） -->
   <link rel="stylesheet" href="game_screen.css" />
+  <!-- 全体フォント設定 -->
+  <link rel="stylesheet" href="globals.css" />
   <!-- React用コンポーネントを読み込み -->
   <script defer src="components/Sparkline.js"></script>
   <script defer src="components/GameImpactList.js"></script>

--- a/public/globals.css
+++ b/public/globals.css
@@ -1,0 +1,3 @@
+html {
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,12 @@
   <!-- Google Fonts を事前接続 -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <!-- Noto Sans JP と Zen Maru Gothic を読み込み -->
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
+  <!-- Inter と Noto Sans JP を読み込み -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
   <!-- 外部CSSを読み込み -->
   <link rel="stylesheet" href="start_screen.css" />
+  <!-- 全体フォント設定 -->
+  <link rel="stylesheet" href="globals.css" />
   
   <!-- React本体をローカルから読み込み -->
   <script src="libs/react.production.min.js"></script>


### PR DESCRIPTION
## Summary
- redesign `IndicatorDetailModal` in Consultant Brief Sheet style
- add hover effects to impact list items
- pass indicator comments to the modal
- create global font settings and apply Inter
- style consultant card pseudo elements

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d76af311c832cb725fb46e36946a0