### PR TITLE
指標詳細モーダルのデザイン刷新

### DIFF
--- a/public/components/GameImpactList.js
+++ b/public/components/GameImpactList.js
@@ -2,9 +2,10 @@
   const { createElement } = React;
 
   // GameImpactList コンポーネント
-  // props.impact は {title, sign}[] の配列を想定
-  function GameImpactList({ impact }) {
-    if (!impact || impact.length === 0) return null;
+  // props.impacts は {title, sign}[] の配列を想定
+  function GameImpactList({ impacts }) {
+    const list = impacts || [];
+    if (list.length === 0) return null;
 
     // icon の色を sign に応じて変えるユーティリティ関数
     const icon = sign => {
@@ -16,10 +17,10 @@
     return createElement(
       'ul',
       { className: 'space-y-1 text-sm list-none' },
-      impact.map((item, idx) =>
+      list.map((item, idx) =>
         createElement(
           'li',
-          { key: idx, className: 'flex items-center' },
+          { key: idx, className: 'flex items-center transition-transform hover:scale-105' },
           icon(item.sign),
           createElement('span', null, item.title)
         )

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -104,7 +104,8 @@
         '</p>',
       correlWith: 'rate',
       impactDesc: '金利を上げると物価上昇が抑えられる傾向があります。',
-      impact: [
+      comment: '金利を上げると物価上昇が抑えられる傾向があります。',
+      impacts: [
         { title: '購買力の低下', sign: 'negative' },
         { title: '企業収益の圧迫', sign: 'negative' }
       ]
@@ -119,7 +120,8 @@
         '</p>',
       correlWith: 'gdp',
       impactDesc: 'GDPが拡大すると失業率は低下しやすくなります。',
-      impact: [
+      comment: 'GDPが拡大すると失業率は低下しやすい傾向',
+      impacts: [
         { title: '消費減退', sign: 'negative' },
         { title: '雇用喪失', sign: 'negative' }
       ]
@@ -134,7 +136,8 @@
         '</p>',
       correlWith: 'rate',
       impactDesc: '低金利政策はGDP成長を促進する効果があります。',
-      impact: [
+      comment: '低金利政策はGDP成長を促進する効果があります。',
+      impacts: [
         { title: '雇用拡大', sign: 'positive' },
         { title: '投資増加', sign: 'positive' }
       ]
@@ -149,7 +152,8 @@
         '</p>',
       correlWith: 'cpi',
       impactDesc: '物価上昇に対抗して引き上げられることが多いです。',
-      impact: [
+      comment: '物価上昇に対抗して引き上げられることが多いです。',
+      impacts: [
         { title: '景気抑制', sign: 'negative' },
         { title: '通貨価値上昇', sign: 'positive' }
       ]
@@ -164,7 +168,8 @@
         '</p>',
       correlWith: 'rate',
       impactDesc: '金利差が拡大すると為替相場が変動しやすくなります。',
-      impact: [
+      comment: '金利差が拡大すると為替相場が変動しやすくなります。',
+      impacts: [
         { title: '輸出企業の利益', sign: 'positive' },
         { title: '輸入物価上昇', sign: 'negative' }
       ]
@@ -179,7 +184,8 @@
         '</p>',
       correlWith: 'rate',
       impactDesc: '政策金利の動きに連動して変化することが多いです。',
-      impact: [
+      comment: '政策金利の動きに連動して変化することが多いです。',
+      impacts: [
         { title: '住宅投資抑制', sign: 'negative' },
         { title: '安全資産需要', sign: 'positive' }
       ]
@@ -194,7 +200,8 @@
         '</p>',
       correlWith: 'unemp',
       impactDesc: '失業率の悪化は消費者マインドを冷やします。',
-      impact: [
+      comment: '失業率の悪化は消費者マインドを冷やします。',
+      impacts: [
         { title: '消費意欲低下', sign: 'negative' }
       ]
     },
@@ -208,7 +215,8 @@
         '</p>',
       correlWith: 'gdp',
       impactDesc: 'PMIの改善はGDP成長率の上昇につながりやすいです。',
-      impact: [
+      comment: 'PMIの改善はGDP成長率の上昇につながりやすいです。',
+      impacts: [
         { title: '景況感向上', sign: 'positive' }
       ]
     },
@@ -222,7 +230,8 @@
         '</p>',
       correlWith: 'gdp',
       impactDesc: '景気拡大期は税収増で比率が改善しやすいです。',
-      impact: [
+      comment: '景気拡大期は税収増で比率が改善しやすいです。',
+      impacts: [
         { title: '将来増税懸念', sign: 'negative' }
       ]
     },
@@ -236,7 +245,8 @@
         '</p>',
       correlWith: 'fx',
       impactDesc: '円安が進むと輸出が増え、貿易収支が改善します。',
-      impact: [
+      comment: '円安が進むと輸出が増え、貿易収支が改善します。',
+      impacts: [
         { title: '通貨安要因', sign: 'negative' },
         { title: '輸出増加', sign: 'positive' }
       ]
@@ -371,7 +381,8 @@
               : null,
           correlLabel:
             indicatorInfo[indicatorInfo[activeIndicator].correlWith]?.label,
-          impact: indicatorInfo[activeIndicator].impact,
+          impacts: indicatorInfo[activeIndicator].impacts,
+          comment: indicatorInfo[activeIndicator].comment,
           onClose: () => setActiveIndicator(null)
         })
       : null,

--- a/public/components/IndicatorDetailModal.js
+++ b/public/components/IndicatorDetailModal.js
@@ -15,7 +15,17 @@
    * 指標詳細をモーダル表示します
    */
   function IndicatorDetailModal(props) {
-    const { title, unit, value, history, onClose, correlation, correlLabel, impact } = props;
+    const {
+      title,
+      unit,
+      value,
+      history,
+      onClose,
+      correlation,
+      correlLabel,
+      impacts,
+      comment
+    } = props;
     const diff = history && history.length >= 2 ? value - history[history.length - 2] : 0;
     const diffStr = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
     const diffColor = diff > 0 ? 'text-green-500' : diff < 0 ? 'text-red-500' : 'text-gray-500';
@@ -29,41 +39,55 @@
         'div',
         {
           className:
-            'relative bg-white rounded-xl shadow-lg w-11/12 max-w-3xl flex sm:flex-col md:flex-row py-6 px-8 space-y-4 md:space-y-0',
+            'relative mx-auto max-w-3xl bg-[#f7f5f1] border border-gray-300 shadow-lg rounded-xl px-10 py-8 hover:bg-[#f9f8f6]'
         },
-        // 左側スパークライン
+        // 左側の縦ライン
+        h('div', {
+          className: 'absolute left-0 top-0 bottom-0 w-1 bg-[#0cb195] rounded-l-xl'
+        }),
+        // 右上のタブ
         h(
           'div',
-          { className: 'md:w-3/5 w-full md:pr-4' },
-          h(Sparkline, { history, height: 180 })
-        ),
-        // 右側情報エリア
-        h(
-          'div',
-          { className: 'md:w-2/5 w-full space-y-4' },
-          // 現在値と前回比
-          h(
-            'h2',
-            { className: `text-3xl font-bold ${diffColor}` },
-            `${value.toFixed(1)}${unit} `,
-            h('span', { className: 'text-xl ml-2' }, `(${diffStr})`)
-          ),
-          // 相関係数
-          correlation !== null && correlLabel
-            ? h(
-                'div',
-                { className: 'bg-gray-100 rounded-xl p-3 text-sm' },
-                `${correlLabel}との相関: ${correlation.toFixed(2)}`
-              )
-            : null,
-          // 影響リスト
-          h(GameImpactList, { impact })
+          {
+            className:
+              'absolute -top-4 right-4 bg-[#00fb00]/90 text-xs px-2 py-1 rounded-b-md shadow'
+          },
+          'INDEX'
         ),
         h(
           'button',
           { className: 'absolute top-2 right-3 text-xl', onClick: onClose },
           '×'
-        )
+        ),
+        // 内容エリア
+        h(
+          'div',
+          { className: 'flex flex-col md:flex-row' },
+          // 左側スパークライン
+          h('div', { className: 'flex-1 mt-4' }, h(Sparkline, { history, height: 180 })),
+          // 右側詳細
+          h(
+            'div',
+            { className: 'w-full md:w-2/5 bg-white rounded-xl shadow-inner p-4 space-y-4' },
+            h(
+              'h2',
+              { className: `text-3xl font-bold ${diffColor}` },
+              `${value.toFixed(1)}${unit} `,
+              h('span', { className: 'text-xl ml-2' }, `(${diffStr})`)
+            ),
+            correlation !== null && correlLabel
+              ? h(
+                  'div',
+                  { className: 'bg-gray-50 rounded-md p-3 text-sm' },
+                  `${correlLabel}との相関: ${correlation.toFixed(2)}`
+                )
+              : null,
+            h(GameImpactList, { impacts })
+          )
+        ),
+        comment
+          ? h('div', { className: 'border-t mt-6 pt-3 text-sm text-gray-600 italic' }, comment)
+          : null
       )
     );
   }

--- a/public/economic_card.html
+++ b/public/economic_card.html
@@ -6,6 +6,8 @@
   <title>経済カード例</title>
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="globals.css">
   <!-- React と ReactDOM (ローカル) -->
   <script src="libs/react.development.js"></script>
   <script src="libs/react-dom.development.js"></script>

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -5,8 +5,9 @@
   <title>ECON – Game</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Googleフォントの読み込み -->
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
   <!-- 追加スタイル -->
+  <link rel="stylesheet" href="globals.css">
   <link rel="stylesheet" href="game_screen.css">
 </head>
 <body class="h-screen overflow-hidden font-[Orbitron]">

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -7,11 +7,12 @@
   <!-- TailwindCSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Googleフォントの読み込み -->
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Orbitron&family=Noto+Sans+JP&display=swap" rel="stylesheet">
   <!-- React と ReactDOM をローカルから読み込み -->
   <script src="libs/react.production.min.js"></script>
   <script src="libs/react-dom.production.min.js"></script>
   <!-- 外部CSS（必要なら） -->
+  <link rel="stylesheet" href="globals.css" />
   <link rel="stylesheet" href="game_screen.css" />
   <!-- React用コンポーネントを読み込み -->
   <script defer src="components/Sparkline.js"></script>

--- a/public/globals.css
+++ b/public/globals.css
@@ -1,0 +1,3 @@
+html {
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -10,9 +10,10 @@
   <!-- Google Fonts を事前接続 -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <!-- Noto Sans JP と Zen Maru Gothic を読み込み -->
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
+  <!-- Inter と Noto Sans JP を読み込み -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
   <!-- 外部CSSを読み込み -->
+  <link rel="stylesheet" href="globals.css" />
   <link rel="stylesheet" href="start_screen.css" />
   
   <!-- React本体をローカルから読み込み -->


### PR DESCRIPTION
## 概要
- IndicatorDetailModal をコンサルタント用ブリーフシート風に改修
- GameImpactList のプロパティ名変更とホバーアニメーション追加
- 各指標情報にコメントを追加しモーダルへ表示
- フォント設定用 globals.css を新設し各 HTML から読み込み
- HTML ファイルで Inter フォントを利用するよう更新

## 使い方
`public/index.html` をブラウザで開きゲームを開始します。経済指標一覧から任意の指標を選ぶと、新しいスタイルの詳細モーダルが表示されます。

------
https://chatgpt.com/codex/tasks/task_e_684d76af311c832cb725fb46e36946a0