### PR TITLE
スタート画面のタイトルとフォントの修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>ecoNova – Start</title>
+  <title>ECONOVA – Start</title>
 
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/public/start_screen.css
+++ b/public/start_screen.css
@@ -8,7 +8,7 @@ body {
     margin: 0;
     padding: 0;
     /* フォントをGoogleフォントで統一 */
-    font-family: 'Noto Sans JP', 'Zen Maru Gothic', sans-serif;
+    font-family: 'Inter', 'Noto Sans JP', sans-serif;
 }
 
 /* スマホでは画像全体が収まるように調整 */

--- a/public/start_screen_react.js
+++ b/public/start_screen_react.js
@@ -48,7 +48,7 @@
           className: 'font-extrabold text-[#00fb00] drop-shadow-[0_0_5px_#00fb00] animate-pulse absolute left-0 w-full text-center transition-opacity duration-700',
           style: { fontSize: '25vh', top: '-8px', opacity: showTitle ? 1 : 0 }
         },
-        "ecoNova",
+        "ECONOVA",
       ),
       // 下部に「タップで開始」テキストを表示
       React.createElement(


### PR DESCRIPTION
## 概要
- スタート画面の表示タイトルを **ECONOVA** に変更
- スタート画面で使用するフォントを `Inter` と `Noto Sans JP` に統一

## 使い方
`npm start` でサーバーを起動し、`http://localhost:8080/index.html` にアクセスしてください。画面をタップするとゲーム画面へ進みます。

## テスト結果


------
https://chatgpt.com/codex/tasks/task_e_684d7bbb9b18832c97cfe81da24ff473