### PR TITLE
ゲーム画面にお知らせ機能を追加

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -71,6 +71,8 @@
   const [showIndicators, setShowIndicators] = useState(false);
   const [activeIndicator, setActiveIndicator] = useState(null);
   const [toast, setToast] = useState(null);
+  // お知らせパネル表示状態
+  const [showMessages, setShowMessages] = useState(false);
   const prevStatsRef = useRef(stats);
   const [diffStats, setDiffStats] = useState({ cpi: 0, unemp: 0, gdp: 0, rate: 0 });
 
@@ -88,6 +90,18 @@
   const [demand, setDemand] = useState(5);
   const [supply, setSupply] = useState(5);
   const [policyRate, setPolicyRate] = useState(0.0);
+
+  // 表示するお知らせの内容
+  const messages = [
+    {
+      title: '消費者信頼感指数調査のお知らせ',
+      body:
+        '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
+        '具体的には以下の項目を調査：\n\n' +
+        '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
+        'これら4項目の平均値が「消費者態度指数」として発表されます。'
+    }
+  ];
 
   // カード表示用のラベルと説明。
   // desc には HTML 文字列を渡し、指標の概要と簡単な影響を文章で示します
@@ -335,7 +349,16 @@
         'div',
         { className: 'flex justify-between items-center' },
         React.createElement('h1', { className: 'text-2xl font-bold three-d-text' }, 'ECON'),
-        React.createElement('button', { onClick: toggleDrawer, className: 'text-2xl' }, '☰')
+        React.createElement(
+          'div',
+          { className: 'flex items-center' },
+          React.createElement(
+            'button',
+            { onClick: () => setShowMessages(o => !o), className: 'text-xl mr-2' },
+            '🔔'
+          ),
+          React.createElement('button', { onClick: toggleDrawer, className: 'text-2xl' }, '☰')
+        )
       ),
       React.createElement(
         'div',
@@ -416,6 +439,37 @@
           )
         )
     ),
+    showMessages &&
+      React.createElement(
+        'div',
+        {
+          id: 'messagePanel',
+          className:
+            'fixed top-16 right-4 w-80 bg-white border border-gray-300 rounded shadow-lg p-4 text-sm z-40'
+        },
+        React.createElement(
+          'div',
+          { className: 'flex justify-between items-center mb-2' },
+          React.createElement('h2', { className: 'font-bold' }, 'お知らせ'),
+          React.createElement(
+            'button',
+            { onClick: () => setShowMessages(false), className: 'text-lg' },
+            '×'
+          )
+        ),
+        React.createElement(
+          'ul',
+          { className: 'space-y-4 list-none' },
+          messages.map((msg, idx) =>
+            React.createElement(
+              'li',
+              { key: idx },
+              React.createElement('p', { className: 'font-semibold' }, msg.title),
+              React.createElement('p', { className: 'whitespace-pre-wrap mt-1' }, msg.body)
+            )
+          )
+        )
+      ),
     toast ? React.createElement('div', { id: 'toast', className: 'fixed top-16 right-4 bg-red-600 text-white px-4 py-2 rounded shadow' }, toast) : null
   );
   }

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -14,7 +14,10 @@
 
   <!-- ヘッダー: 収入と評価を表示 -->
   <header class="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900/90 text-white flex justify-between items-center px-4 py-2">
-    <button id="drawerBtn" class="text-2xl">☰</button>
+    <div class="flex items-center gap-2">
+      <button id="messageBtn" class="text-xl">🔔</button>
+      <button id="drawerBtn" class="text-2xl">☰</button>
+    </div>
     <div class="flex gap-2 text-lg font-mono">
       <span class="flex items-center gap-1 p-1 rounded bg-green-100 text-green-600">
         <span class="w-2 h-2 bg-current rounded"></span>
@@ -38,6 +41,24 @@
       <button class="w-full text-left py-2 px-3 bg-gray-100 rounded">📜 履歴</button>
     </nav>
   </aside>
+
+  <!-- お知らせパネル -->
+  <div id="messagePanel" class="fixed top-16 right-4 w-80 bg-white border border-gray-300 rounded shadow-lg p-4 text-sm z-50 hidden">
+    <button id="closeMessage" class="absolute top-1 right-2 text-lg">×</button>
+    <h2 class="font-bold mb-2">お知らせ</h2>
+    <p class="font-semibold">消費者信頼感指数調査のお知らせ</p>
+    <p class="whitespace-pre-line mt-1">
+調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています
+具体的には以下の項目を調査：
+
+暮らし向き
+収入の増え方
+雇用環境
+耐久消費財の買い時判断
+
+これら4項目の平均値が「消費者態度指数」として発表されます。
+    </p>
+  </div>
 
   <!-- モーダル -->
   <div id="statsModal" class="fixed inset-0 hidden items-center justify-center z-50">

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -8,6 +8,9 @@ window.addEventListener('DOMContentLoaded', () => {
   // --- 要素の取得 ----------------------------------
   const drawer = document.getElementById('drawer');
   const drawerBtn = document.getElementById('drawerBtn');
+  const messageBtn = document.getElementById('messageBtn');
+  const messagePanel = document.getElementById('messagePanel');
+  const closeMessage = document.getElementById('closeMessage');
   const overlay = document.getElementById('drawerOverlay');
   const statsBtn = document.getElementById('statsBtn');
   const modal = document.getElementById('statsModal');
@@ -85,6 +88,13 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // オーバーレイをクリックした場合も閉じる
   overlay.addEventListener('click', closeDrawer);
+
+  // --- お知らせパネル表示処理 ----------------------
+  function toggleMessage() {
+    messagePanel.classList.toggle('hidden');
+  }
+  messageBtn.addEventListener('click', toggleMessage);
+  closeMessage.addEventListener('click', toggleMessage);
 
   // --- モーダル表示処理 ----------------------------
   statsBtn.addEventListener('click', () => {


### PR DESCRIPTION
## 変更点
- ゲーム画面ヘッダーに🔔ボタンを追加し、お知らせ一覧を表示できるようにしました
- React 版 `GameScreen` とプレーン版 HTML/JS の両方に対応
- お知らせには消費者信頼感指数調査の案内文を初期表示
- 既存テストを実行し、すべて成功することを確認済み


------
https://chatgpt.com/codex/tasks/task_e_684d855b17b4832c96bf099b775bb99d