### PR TITLE
UI更新と影響表示の改善

### DIFF
--- a/public/components/GameImpactList.js
+++ b/public/components/GameImpactList.js
@@ -3,14 +3,15 @@
 
   // GameImpactList コンポーネント
   // props.impacts は {title, sign}[] の配列を想定
-  function GameImpactList({ impacts }) {
+  function GameImpactList({ impacts, trend = 0 }) {
     const list = impacts || [];
     if (list.length === 0) return null;
 
     // icon の色を sign に応じて変えるユーティリティ関数
     const icon = sign => {
       const base = 'inline-block w-4 h-4 mr-1';
-      const cls = sign === 'positive' ? 'text-green-500' : 'text-red-500';
+      const isGood = (sign === 'positive' && trend > 0) || (sign === 'negative' && trend < 0);
+      const cls = trend === 0 ? 'text-gray-500' : isGood ? 'text-lime-500' : 'text-red-500';
       return createElement('span', { className: `${base} ${cls}` }, sign === 'positive' ? '▲' : '▼');
     };
 

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -383,6 +383,7 @@
             indicatorInfo[indicatorInfo[activeIndicator].correlWith]?.label,
           impacts: indicatorInfo[activeIndicator].impacts,
           comment: indicatorInfo[activeIndicator].comment,
+          trend: diffStats[activeIndicator],
           onClose: () => setActiveIndicator(null)
         })
       : null,

--- a/public/components/IndicatorDetailModal.js
+++ b/public/components/IndicatorDetailModal.js
@@ -24,7 +24,8 @@
       correlation,
       correlLabel,
       impacts,
-      comment
+      comment,
+      trend
     } = props;
     const diff = history && history.length >= 2 ? value - history[history.length - 2] : 0;
     const diffStr = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
@@ -45,14 +46,14 @@
         h('div', {
           className: 'absolute left-0 top-0 bottom-0 w-1 bg-[#0cb195] rounded-l-xl'
         }),
-        // 右上のタブ
+        // 左上に配置するタブ
 
         h(
           'div',
           {
             className:
 
-              'absolute -top-4 right-4 bg-[#00fb00]/90 text-xs px-2 py-1 rounded-b-md shadow'
+              'absolute -top-4 left-4 bg-[#00fb00]/90 text-xs px-2 py-1 rounded-b-md shadow'
           },
           'INDEX'
 
@@ -85,7 +86,7 @@
                   `${correlLabel}との相関: ${correlation.toFixed(2)}`
                 )
               : null,
-            h(GameImpactList, { impacts })
+            h(GameImpactList, { impacts, trend })
           )
         ),
         comment


### PR DESCRIPTION
## 概要
- 指標詳細モーダルの「INDEX」付箋を右上から左上に移動
- GameImpactList が指標の増減に応じて三角アイコンの色を変えるよう対応
- GameScreen から指標変化量を渡すことで、詳細モーダル内の影響リストが現在の状況に合わせて色分けされるように

## 動作確認
- `npm install --silent`
- `npm test --silent`
  - すべてのテストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_684d86056acc832cbf94a6afc0f7d78d