### PR TITLE
経済指標詳細UIの改善

### DIFF
--- a/public/components/GameImpactList.js
+++ b/public/components/GameImpactList.js
@@ -2,16 +2,18 @@
   const { createElement } = React;
 
   // GameImpactList コンポーネント
-  // props.impacts は {title, sign}[] の配列を想定
-  function GameImpactList({ impacts }) {
+  // props.impacts は {title, desc}[] の配列を想定
+  // props.direction は 1 なら指数上昇、-1 なら下降を表します
+  function GameImpactList({ impacts, direction }) {
     const list = impacts || [];
     if (list.length === 0) return null;
 
-    // icon の色を sign に応じて変えるユーティリティ関数
-    const icon = sign => {
+    // 上昇・下降に合わせたアイコンを返すユーティリティ関数
+    const icon = () => {
       const base = 'inline-block w-4 h-4 mr-1';
-      const cls = sign === 'positive' ? 'text-green-500' : 'text-red-500';
-      return createElement('span', { className: `${base} ${cls}` }, sign === 'positive' ? '▲' : '▼');
+      const cls = direction > 0 ? 'text-lime-500' : 'text-red-500';
+      const arrow = direction > 0 ? '▲' : '▼';
+      return createElement('span', { className: `${base} ${cls}` }, arrow);
     };
 
     return createElement(
@@ -20,8 +22,12 @@
       list.map((item, idx) =>
         createElement(
           'li',
-          { key: idx, className: 'flex items-center transition-transform hover:scale-105' },
-          icon(item.sign),
+          {
+            key: idx,
+            className: 'flex items-center transition-transform hover:scale-105',
+            title: item.desc || ''
+          },
+          icon(),
           createElement('span', null, item.title)
         )
       )

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -120,8 +120,8 @@
       impactDesc: '金利を上げると物価上昇が抑えられる傾向があります。',
       comment: '金利を上げると物価上昇が抑えられる傾向があります。',
       impacts: [
-        { title: '購買力の低下', sign: 'negative' },
-        { title: '企業収益の圧迫', sign: 'negative' }
+        { title: '購買力の低下', desc: '物価が上がると同じお金で買える量が減ります' },
+        { title: '企業収益の圧迫', desc: 'コスト増で儲けが少なくなります' }
       ]
     },
     unemp: {
@@ -136,8 +136,8 @@
       impactDesc: 'GDPが拡大すると失業率は低下しやすくなります。',
       comment: 'GDPが拡大すると失業率は低下しやすい傾向',
       impacts: [
-        { title: '消費減退', sign: 'negative' },
-        { title: '雇用喪失', sign: 'negative' }
+        { title: '消費減退', desc: '仕事が少ないとお金を使う人が減ります' },
+        { title: '雇用喪失', desc: '働く場所がなくなることです' }
       ]
     },
     gdp: {
@@ -152,8 +152,8 @@
       impactDesc: '低金利政策はGDP成長を促進する効果があります。',
       comment: '低金利政策はGDP成長を促進する効果があります。',
       impacts: [
-        { title: '雇用拡大', sign: 'positive' },
-        { title: '投資増加', sign: 'positive' }
+        { title: '雇用拡大', desc: '生産が増えると働く人が増えます' },
+        { title: '投資増加', desc: '景気が良いと企業はお金を使って拡大します' }
       ]
     },
     rate: {
@@ -168,8 +168,8 @@
       impactDesc: '物価上昇に対抗して引き上げられることが多いです。',
       comment: '物価上昇に対抗して引き上げられることが多いです。',
       impacts: [
-        { title: '景気抑制', sign: 'negative' },
-        { title: '通貨価値上昇', sign: 'positive' }
+        { title: '景気抑制', desc: '金利が上がると借金が増えづらくなります' },
+        { title: '通貨価値上昇', desc: '金利が高い国の通貨は価値が上がりやすいです' }
       ]
     },
     fx: {
@@ -184,8 +184,8 @@
       impactDesc: '金利差が拡大すると為替相場が変動しやすくなります。',
       comment: '金利差が拡大すると為替相場が変動しやすくなります。',
       impacts: [
-        { title: '輸出企業の利益', sign: 'positive' },
-        { title: '輸入物価上昇', sign: 'negative' }
+        { title: '輸出企業の利益', desc: '円安になると海外で売りやすくなります' },
+        { title: '輸入物価上昇', desc: '円安で外国からの買い物が高くなります' }
       ]
     },
     yield: {
@@ -200,8 +200,8 @@
       impactDesc: '政策金利の動きに連動して変化することが多いです。',
       comment: '政策金利の動きに連動して変化することが多いです。',
       impacts: [
-        { title: '住宅投資抑制', sign: 'negative' },
-        { title: '安全資産需要', sign: 'positive' }
+        { title: '住宅投資抑制', desc: '長期金利が高いと家を建てにくくなります' },
+        { title: '安全資産需要', desc: '国債は安定した投資先とされます' }
       ]
     },
     cci: {
@@ -216,7 +216,7 @@
       impactDesc: '失業率の悪化は消費者マインドを冷やします。',
       comment: '失業率の悪化は消費者マインドを冷やします。',
       impacts: [
-        { title: '消費意欲低下', sign: 'negative' }
+        { title: '消費意欲低下', desc: '将来が不安だと買い物を控えます' }
       ]
     },
     pmi: {
@@ -231,7 +231,7 @@
       impactDesc: 'PMIの改善はGDP成長率の上昇につながりやすいです。',
       comment: 'PMIの改善はGDP成長率の上昇につながりやすいです。',
       impacts: [
-        { title: '景況感向上', sign: 'positive' }
+        { title: '景況感向上', desc: '製造業が元気だと景気も明るくなります' }
       ]
     },
     debtGDP: {
@@ -246,7 +246,7 @@
       impactDesc: '景気拡大期は税収増で比率が改善しやすいです。',
       comment: '景気拡大期は税収増で比率が改善しやすいです。',
       impacts: [
-        { title: '将来増税懸念', sign: 'negative' }
+        { title: '将来増税懸念', desc: '国の借金が多いと税金が上がるかもしれません' }
       ]
     },
     trade: {
@@ -261,8 +261,8 @@
       impactDesc: '円安が進むと輸出が増え、貿易収支が改善します。',
       comment: '円安が進むと輸出が増え、貿易収支が改善します。',
       impacts: [
-        { title: '通貨安要因', sign: 'negative' },
-        { title: '輸出増加', sign: 'positive' }
+        { title: '通貨安要因', desc: '赤字が続くと円の価値が下がることがあります' },
+        { title: '輸出増加', desc: '円安なら海外へ多く売れます' }
       ]
     }
   };

--- a/public/components/IndicatorDetailModal.js
+++ b/public/components/IndicatorDetailModal.js
@@ -29,6 +29,7 @@
     const diff = history && history.length >= 2 ? value - history[history.length - 2] : 0;
     const diffStr = diff > 0 ? `+${diff.toFixed(1)}` : diff.toFixed(1);
     const diffColor = diff > 0 ? 'text-green-500' : diff < 0 ? 'text-red-500' : 'text-gray-500';
+    const direction = diff >= 0 ? 1 : -1;
 
     return h(
       'div',
@@ -51,11 +52,9 @@
           'div',
           {
             className:
-
-              'absolute -top-4 right-4 bg-[#00fb00]/90 text-xs px-2 py-1 rounded-b-md shadow'
+              'absolute -top-4 left-4 bg-[#00fb00]/90 text-xs px-2 py-1 rounded-b-md shadow'
           },
           'INDEX'
-
         ),
         h(
           'button',
@@ -85,7 +84,7 @@
                   `${correlLabel}との相関: ${correlation.toFixed(2)}`
                 )
               : null,
-            h(GameImpactList, { impacts })
+            h(GameImpactList, { impacts, direction })
           )
         ),
         comment


### PR DESCRIPTION
## 変更点
- 指標詳細モーダルの"INDEX"付箋を右上から左上へ移動
- GameImpactListを改良し、指標の増減に応じて矢印色を変更
- 各指標の影響リストに簡単な説明を追加し、ツールチップ表示に対応
- 影響リスト表示用にdirection値をIndicatorDetailModalから渡すよう更新

## 確認手順
1. `npm install`
2. `npm test` を実行してテストが通ることを確認
3. `public/game_screen_react.html` をブラウザで開き、指標カードをクリックして詳細モーダルを表示
4. 付箋が左上にあること、影響リストの矢印色が指標変化に合わせて変わること、ホバーで説明が表示されることを確認

------
https://chatgpt.com/codex/tasks/task_e_684d880badc4832cbaba85b85fe2fd15