### PR TITLE
お知らせとドロワーの重なりを修正

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -53,3 +53,8 @@ button {
     font-size: 1.2rem;
     padding: 0.5em 2em;
 }
+
+/* お知らせパネルのスタイル */
+#noticePanel {
+    z-index: 50; /* ドロワーより上に表示されないよう調整 */
+}

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -18,6 +18,9 @@
         <h1 class="text-lg font-bold">ECON ゲーム</h1>
         <div class="flex items-center">
             <span id="rating" class="mr-4 text-sm">評価: ★0</span>
+            <!-- お知らせ表示ボタン -->
+            <button id="noticeButton" class="bg-green-500 px-3 py-1 rounded mr-2">お知らせ</button>
+            <!-- メニューボタン -->
             <button id="drawerButton" class="bg-blue-500 px-3 py-1 rounded">メニュー</button>
         </div>
     </header>
@@ -43,6 +46,11 @@
         <ul id="indexList" class="p-2 border-t"></ul>
         <!-- 選択した指数の説明を表示するカード -->
         <div id="indexDetailCard" class="p-2"></div>
+    </div>
+
+    <!-- お知らせパネル -->
+    <div id="noticePanel" class="fixed top-0 left-0 right-0 bg-white bg-opacity-90 p-4 shadow hidden">
+        <p>ここに最新のお知らせが表示されます。</p>
     </div>
 </body>
 </html>

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -8,6 +8,9 @@ function initializeGameScreen() {
     var drawer = document.getElementById('drawer');
     var openButton = document.getElementById('drawerButton');
     var closeButton = document.getElementById('closeDrawer');
+    // お知らせ関連の要素を取得
+    var noticeButton = document.getElementById('noticeButton');
+    var noticePanel = document.getElementById('noticePanel');
 
     // 経済指数のリストと詳細表示用カードを取得
     var indexList = document.getElementById('indexList');
@@ -52,9 +55,32 @@ function initializeGameScreen() {
         drawer.classList.toggle('open');
     }
 
+    // お知らせを閉じる関数
+    function closeNotice() {
+        if (noticePanel && !noticePanel.classList.contains('hidden')) {
+            noticePanel.classList.add('hidden');
+        }
+    }
+
+    // お知らせを開閉する関数
+    function toggleNotice() {
+        if (noticePanel) {
+            noticePanel.classList.toggle('hidden');
+        }
+    }
+
     // メニューボタンでドロワーを開閉
     if (openButton) {
-        openButton.addEventListener('click', toggleDrawer);
+        openButton.addEventListener('click', function() {
+            // ドロワーを開く際にお知らせを閉じる
+            closeNotice();
+            toggleDrawer();
+        });
+    }
+
+    // お知らせボタンでパネルを開閉
+    if (noticeButton) {
+        noticeButton.addEventListener('click', toggleNotice);
     }
 
     // 閉じるボタンでドロワーを閉じる

--- a/tests/game_screen.test.js
+++ b/tests/game_screen.test.js
@@ -12,6 +12,8 @@ describe('public/game_screen.js', () => {
         <ul id="indexList"></ul>
         <div id="indexDetailCard"></div>
       </div>
+      <button id="noticeButton"></button>
+      <div id="noticePanel" class="hidden"></div>
     `;
 
     // モジュールを読み込む
@@ -34,5 +36,17 @@ describe('public/game_screen.js', () => {
     firstItem.click();
     const detail = document.getElementById('indexDetailCard');
     expect(detail.textContent).toContain(window.economicIndices[0].impact);
+  });
+
+  test('ドロワーを開くとお知らせが閉じる', () => {
+    const noticeBtn = document.getElementById('noticeButton');
+    const noticePanel = document.getElementById('noticePanel');
+    const drawerBtn = document.getElementById('drawerButton');
+    // 先にお知らせを開く
+    noticeBtn.click();
+    expect(noticePanel.classList.contains('hidden')).toBe(false);
+    // メニューボタンをクリックしてドロワーを開く
+    drawerBtn.click();
+    expect(noticePanel.classList.contains('hidden')).toBe(true);
   });
 });


### PR DESCRIPTION
## 変更点
- お知らせボタンとパネルを追加
- ドロワーを開くとお知らせパネルが閉じるよう機能追加
- CSS にお知らせパネルのスタイルを追加
- テストを更新し新しい挙動を確認

## 使い方
ゲーム画面右上の **お知らせ** ボタンを押すとお知らせパネルが表示されます。メニュー(ドロワー)を開くと自動的にお知らせは閉じます。

------
https://chatgpt.com/codex/tasks/task_e_684f5fe2a770832cb293eaa6a650269d