### PR TITLE
サイドドロワー表示時にお知らせを自動で閉じる修正

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -313,7 +313,14 @@
     return () => clearTimeout(timer);
   }, []);
 
-  const toggleDrawer = () => setDrawerOpen(o => !o);
+  // ドロワーを開く/閉じる関数
+  const toggleDrawer = () =>
+    setDrawerOpen(o => {
+      const next = !o;
+      // ドロワーを開くときはお知らせパネルを閉じる
+      if (next) setShowMessages(false);
+      return next;
+    });
   const closeDrawer = () => {
     setDrawerOpen(false);
     setShowIndicators(false);

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -75,6 +75,8 @@ window.addEventListener('DOMContentLoaded', () => {
   function openDrawer() {
     drawer.classList.add('drawer-open');
     overlay.classList.add('overlay-show');
+    // ドロワーを開くときはお知らせパネルを閉じる
+    messagePanel.classList.add('hidden');
   }
 
   function closeDrawer() {


### PR DESCRIPTION
## 変更内容
- React 版 `GameScreen` コンポーネントの `toggleDrawer` を修正し、ドロワーを開く際にお知らせパネルを閉じる処理を追加
- プレーンな `game_screen.js` でもドロワーを開く際にお知らせパネルを非表示にするよう変更

## 使い方
ブラウザで `public/index.html` を開き、ゲーム画面へ進みます。右上の「☰」ボタンでサイドドロワーを開くと、自動的にお知らせが閉じるようになっています。

------
https://chatgpt.com/codex/tasks/task_e_684f62411570832c9eb3432337c6f638