### PR TITLE
お知らせ一覧のパネル表示に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ npm install  # 依存パッケージのインストール
 npm test     # Jest でテストを実行
 ```
 
+## 🔔 お知らせ一覧機能
+
+ゲーム画面右上の🔔ボタンを押すと、お知らせパネルが開きます。
+過去に受け取ったメッセージはローカルストレージに保存され、
+一覧として表示されます。各カードには以下の Tailwind クラスを
+適用しています。
+
+```
+bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
+```
+
+項目をクリックすると `notification_detail.html` に遷移し、
+内容確認と返信が行えます。
+
 ---
 
 ## 🙋‍♂️ Contributors

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -91,17 +91,27 @@
   const [supply, setSupply] = useState(5);
   const [policyRate, setPolicyRate] = useState(0.0);
 
-  // 表示するお知らせの内容
-  const messages = [
-    {
-      title: '消費者信頼感指数調査のお知らせ',
-      body:
-        '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
-        '具体的には以下の項目を調査：\n\n' +
-        '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
-        'これら4項目の平均値が「消費者態度指数」として発表されます。'
+  // お知らせメッセージ一覧を保持
+  const [messages, setMessages] = useState(() => {
+    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+    if (saved.length === 0) {
+      saved.push({
+        title: '消費者信頼感指数調査のお知らせ',
+        body:
+          '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
+          '具体的には以下の項目を調査：\n\n' +
+          '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
+          'これら4項目の平均値が「消費者態度指数」として発表されます。'
+      });
+      localStorage.setItem('notifications', JSON.stringify(saved));
     }
-  ];
+    return saved;
+  });
+
+  // messages が変わるたびローカルストレージへ保存
+  useEffect(() => {
+    localStorage.setItem('notifications', JSON.stringify(messages));
+  }, [messages]);
 
   // カード表示用のラベルと説明。
   // desc には HTML 文字列を渡し、指標の概要と簡単な影響を文章で示します
@@ -361,7 +371,11 @@
           { className: 'flex items-center' },
           React.createElement(
             'button',
-            { onClick: () => setShowMessages(o => !o), className: 'text-xl mr-2' },
+            {
+              // お知らせパネルの開閉
+              onClick: () => setShowMessages((o) => !o),
+              className: 'text-xl mr-2'
+            },
             '🔔'
           ),
           React.createElement('button', { onClick: toggleDrawer, className: 'text-2xl' }, '☰')
@@ -466,13 +480,19 @@
         ),
         React.createElement(
           'ul',
-          { className: 'space-y-4 list-none' },
+          { className: 'space-y-4 list-none', id: 'notificationListReact' },
           messages.map((msg, idx) =>
             React.createElement(
               'li',
-              { key: idx },
-              React.createElement('p', { className: 'font-semibold' }, msg.title),
-              React.createElement('p', { className: 'whitespace-pre-wrap mt-1' }, msg.body)
+              {
+                key: idx,
+                className:
+                  'bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer',
+                onClick: () => {
+                  window.location.href = `notification_detail.html?index=${idx}`;
+                }
+              },
+              React.createElement('p', { className: 'font-semibold' }, msg.title)
             )
           )
         )

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -46,18 +46,8 @@
   <div id="messagePanel" class="fixed top-16 right-4 w-80 bg-white border border-gray-300 rounded shadow-lg p-4 text-sm z-50 hidden">
     <button id="closeMessage" class="absolute top-1 right-2 text-lg">×</button>
     <h2 class="font-bold mb-2">お知らせ</h2>
-    <p class="font-semibold">消費者信頼感指数調査のお知らせ</p>
-    <p class="whitespace-pre-line mt-1">
-調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています
-具体的には以下の項目を調査：
-
-暮らし向き
-収入の増え方
-雇用環境
-耐久消費財の買い時判断
-
-これら4項目の平均値が「消費者態度指数」として発表されます。
-    </p>
+    <!-- メッセージ一覧をここに表示 -->
+    <ul id="notificationList" class="space-y-4"></ul>
   </div>
 
   <!-- モーダル -->

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -92,8 +92,46 @@ window.addEventListener('DOMContentLoaded', () => {
   overlay.addEventListener('click', closeDrawer);
 
   // --- お知らせパネル表示処理 ----------------------
+  // ローカルストレージからメッセージを読み込み
+  function loadNotifications() {
+    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+    if (saved.length === 0) {
+      // 初回のみサンプルメッセージを登録
+      saved.push({
+        title: '消費者信頼感指数調査のお知らせ',
+        body:
+          '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
+          '具体的には以下の項目を調査：\n\n' +
+          '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
+          'これら4項目の平均値が「消費者態度指数」として発表されます。'
+      });
+      localStorage.setItem('notifications', JSON.stringify(saved));
+    }
+    return saved;
+  }
+
+  // パネル内にメッセージを描画
+  function renderNotifications() {
+    const list = document.getElementById('notificationList');
+    list.innerHTML = '';
+    const saved = loadNotifications();
+    saved.forEach((msg, idx) => {
+      const li = document.createElement('li');
+      li.className =
+        'bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
+      li.innerHTML = `<p class="font-semibold">${msg.title}</p>`;
+      li.addEventListener('click', () => {
+        window.location.href = `notification_detail.html?index=${idx}`;
+      });
+      list.appendChild(li);
+    });
+  }
+
   function toggleMessage() {
     messagePanel.classList.toggle('hidden');
+    if (!messagePanel.classList.contains('hidden')) {
+      renderNotifications();
+    }
   }
   messageBtn.addEventListener('click', toggleMessage);
   closeMessage.addEventListener('click', toggleMessage);

--- a/public/notification_detail.html
+++ b/public/notification_detail.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>お知らせ詳細</title>
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-4">
+  <h1 id="detailTitle" class="text-xl font-bold mb-4"></h1>
+  <p id="detailBody" class="whitespace-pre-wrap mb-4"></p>
+  <!-- 回答入力欄 -->
+  <textarea id="answer" class="w-full border p-2 rounded mb-4" rows="4" placeholder="ここに回答を入力"></textarea>
+  <button id="sendBtn" class="bg-blue-500 text-white px-4 py-2 rounded">送信</button>
+  <script src="notification_detail.js"></script>
+</body>
+</html>

--- a/public/notification_detail.js
+++ b/public/notification_detail.js
@@ -1,0 +1,18 @@
+// お知らせ詳細画面用スクリプト
+// URL パラメータからメッセージのインデックスを取得し、内容を表示します
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const index = parseInt(params.get('index'), 10);
+  const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+  const msg = saved[index] || { title: '不明', body: '' };
+
+  // タイトルと本文を表示
+  document.getElementById('detailTitle').textContent = msg.title;
+  document.getElementById('detailBody').textContent = msg.body;
+
+  // 送信ボタンは簡易的にアラートを表示
+  document.getElementById('sendBtn').addEventListener('click', () => {
+    alert('回答を送信しました');
+  });
+});


### PR DESCRIPTION
## 変更内容
- お知らせ一覧ページを削除し、ゲーム画面内のパネルで表示するよう変更
- `game_screen.js` にローカルストレージからメッセージを読み込む処理を追加
- React 版 `GameScreen.js` も同様にパネルで一覧を表示
- `game_screen.html` のお知らせパネルをメッセージリスト化
- README の説明を更新

## 動作確認
- `npm test` を実行（jest が無いため失敗）


------
https://chatgpt.com/codex/tasks/task_e_684f663053ec832cb9c310123f0d61b4