### PR TITLE
お知らせ一覧の黒ベース化

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ npm test     # Jest でテストを実行
 
 ## 🔔 お知らせ一覧機能
 
+
 `notifications.html` を開くと、ゲーム内で受け取ったお知らせを一覧できます。
-カード部分は次の Tailwind クラスを使用したシンプルなデザインです。
+カード部分は黒ベースの以下の Tailwind クラスを使ったシンプルなデザインです。
 
 ```
-bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
+bg-gray-800 text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
 ```
 
 項目をクリックすると `notification_detail.html` に遷移し、

--- a/public/notification_detail.html
+++ b/public/notification_detail.html
@@ -7,12 +7,12 @@
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-4">
+<body class="bg-black text-white min-h-screen p-4">
   <h1 id="detailTitle" class="text-xl font-bold mb-4"></h1>
   <p id="detailBody" class="whitespace-pre-wrap mb-4"></p>
   <!-- 回答入力欄 -->
-  <textarea id="answer" class="w-full border p-2 rounded mb-4" rows="4" placeholder="ここに回答を入力"></textarea>
-  <button id="sendBtn" class="bg-blue-500 text-white px-4 py-2 rounded">送信</button>
+  <textarea id="answer" class="w-full border p-2 rounded mb-4 bg-gray-800 text-white" rows="4" placeholder="ここに回答を入力"></textarea>
+  <button id="sendBtn" class="bg-blue-600 text-white px-4 py-2 rounded">送信</button>
   <script src="notification_detail.js"></script>
 </body>
 </html>

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -7,8 +7,8 @@
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-4">
-  <h1 class="text-xl font-bold mb-4">お知らせ一覧</h1>
+<body class="bg-black text-white min-h-screen p-4">
+  <h1 class="text-xl font-bold mb-4 text-white">お知らせ一覧</h1>
   <!-- メッセージを表示するリスト -->
   <ul id="notificationList" class="space-y-4"></ul>
   <!-- 一覧表示用のスクリプト -->

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 各メッセージをリストに追加
   saved.forEach((msg, idx) => {
     const li = document.createElement('li');
-    li.className = 'bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
+    li.className = 'bg-gray-800 text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
     li.innerHTML = `<p class="font-semibold">${msg.title}</p>`;
     li.addEventListener('click', () => {
       // 詳細画面へ遷移するときはインデックスをクエリパラメータで渡す


### PR DESCRIPTION
## 変更内容
- `notifications.html` の背景と文字色を黒基調へ変更
- 通知リストのカードを黒ベースにするよう `notifications.js` を更新
- お知らせ詳細画面(`notification_detail.html`)も黒背景に対応
- README の該当箇所を新しいクラス名に更新

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850de5cb488832caf1c5f33887ddced