### PR TITLE
通知カードの背景色を明るく変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ npm test     # Jest でテストを実行
 
 ## 🔔 お知らせ一覧機能
 
+
 `notifications.html` を開くと、ゲーム内で受け取ったお知らせを一覧できます。
-カード部分は次の Tailwind クラスを使用したシンプルなデザインです。
+カード部分は より明るい #cfe4de 色の以下の Tailwind クラスを使ったシンプルなデザインです。
 
 ```
-bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
+bg-[#cfe4de] text-black shadow-lg rounded-xl p-4 border-l-4 border-blue-400
 ```
 
 項目をクリックすると `notification_detail.html` に遷移し、

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -7,7 +7,7 @@
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-4">
+<body class="bg-gray-100 min-h-screen p-4">
   <h1 class="text-xl font-bold mb-4">お知らせ一覧</h1>
   <!-- メッセージを表示するリスト -->
   <ul id="notificationList" class="space-y-4"></ul>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -22,7 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // 各メッセージをリストに追加
   saved.forEach((msg, idx) => {
     const li = document.createElement('li');
-    li.className = 'bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
+    // 背景色を明るめの #cfe4de に変更し、通知をより見やすくする
+    // 明るい色のため文字色は黒に設定する
+    li.className = 'bg-[#cfe4de] text-black shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
     li.innerHTML = `<p class="font-semibold">${msg.title}</p>`;
     li.addEventListener('click', () => {
       // 詳細画面へ遷移するときはインデックスをクエリパラメータで渡す


### PR DESCRIPTION
## 変更内容
- お知らせカードの色を `#cfe4de` に変更し、文字色を黒へ調整しました
- README の通知セクションも新しいクラス定義に更新しました

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850de5cb488832caf1c5f33887ddced