### PR TITLE
通知画面のデザインをグラデーション化

### DIFF
--- a/public/notification_detail.html
+++ b/public/notification_detail.html
@@ -4,15 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>お知らせ詳細</title>
-  <!-- Tailwind CDN -->
+  <!-- Tailwind CDN と共通スタイル読み込み -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gray-100 p-4">
-  <h1 id="detailTitle" class="text-xl font-bold mb-4"></h1>
-  <p id="detailBody" class="whitespace-pre-wrap mb-4"></p>
-  <!-- 回答入力欄 -->
-  <textarea id="answer" class="w-full border p-2 rounded mb-4" rows="4" placeholder="ここに回答を入力"></textarea>
-  <button id="sendBtn" class="bg-blue-500 text-white px-4 py-2 rounded">送信</button>
+<body class="bg-gray-100 min-h-screen">
+  <div class="detail-container">
+    <div class="gradient-bar detail-header">
+      <h1 id="detailTitle" class="text-xl font-bold"></h1>
+    </div>
+    <div class="detail-content">
+      <p id="detailBody" class="whitespace-pre-wrap mb-4"></p>
+      <!-- 回答入力欄 -->
+      <textarea id="answer" rows="4" placeholder="ここに回答を入力"></textarea>
+      <button id="sendBtn">送信</button>
+    </div>
+  </div>
   <script src="notification_detail.js"></script>
 </body>
 </html>

--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -1,0 +1,67 @@
+/* 共通スタイル - お知らせ関連ページ */
+body {
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+}
+
+/* グラデーションのヘッダーバー */
+.gradient-bar {
+  background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+  color: #fff;
+}
+
+/* 一覧のバー(リスト項目)に適用するスタイル */
+.notification-item {
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  color: #fff;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+  transition: all 0.3s ease;
+}
+
+.notification-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+/* 詳細画面のコンテナ */
+.detail-container {
+  max-width: 900px;
+  margin: 2rem auto;
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.08), 0 16px 32px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+  border: 1px solid #f0f0f0;
+}
+
+.detail-header {
+  padding: 48px 40px;
+  text-align: center;
+}
+
+.detail-content {
+  padding: 32px 24px;
+}
+
+#answer {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+}
+
+#sendBtn {
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: none;
+  margin-top: 1rem;
+  cursor: pointer;
+}
+
+#sendBtn:hover {
+  opacity: 0.9;
+}

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -4,13 +4,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>お知らせ一覧</title>
-  <!-- Tailwind CDN -->
+  <!-- Tailwind CDN と共通スタイル読み込み -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="notification_style.css" />
 </head>
 <body class="bg-gray-100 min-h-screen p-4">
-  <h1 class="text-xl font-bold mb-4">お知らせ一覧</h1>
+  <!-- タイトルバー -->
+  <header class="gradient-bar p-4 mb-4 text-center rounded-lg shadow">
+    <h1 class="text-xl font-bold">お知らせ一覧</h1>
+  </header>
   <!-- メッセージを表示するリスト -->
-  <ul id="notificationList" class="space-y-4"></ul>
+  <ul id="notificationList"></ul>
   <!-- 一覧表示用のスクリプト -->
   <script src="notifications.js"></script>
 </body>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -22,8 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // 各メッセージをリストに追加
   saved.forEach((msg, idx) => {
     const li = document.createElement('li');
-    // 背景色を#49796bに設定し、影を付けて立体感を出す
-    li.className = 'bg-[#49796b] text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer';
+    // デザイン用クラスを付与（グラデーションのバー表示）
+    li.className = 'notification-item cursor-pointer';
     li.innerHTML = `<p class="font-semibold">${msg.title}</p>`;
     li.addEventListener('click', () => {
       // 詳細画面へ遷移するときはインデックスをクエリパラメータで渡す


### PR DESCRIPTION
## 変更内容
- お知らせ一覧・詳細ページ共通のスタイル `notification_style.css` を追加
- 一覧画面にグラデーションヘッダーを追加し、各項目も同色系のバー表示に変更
- 詳細画面を新しいデザインで囲み、入力欄と送信ボタンのスタイルを調整
- JavaScript を更新し、生成するリストに新しいクラスを付与

## 使い方
`npm start` でサーバーを起動後、`/notifications.html` から一覧を確認できます。項目をクリックすると詳細画面が表示され、テキストを入力して送信ボタンを押すだけです。


------
https://chatgpt.com/codex/tasks/task_e_6850e41f257c832cb1fecb5af8939781