### PR TITLE
お知らせ一覧バーを明るいグラデーションに

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ npm test     # Jest でテストを実行
 
 
 `notifications.html` を開くと、ゲーム内で受け取ったお知らせを一覧できます。
-カード部分は #49796b 色の以下の Tailwind クラスを使ったシンプルなデザインです。
+カード部分は淡いグラデーションを背景にしたシンプルなデザインです。
 
 ```
-bg-[#49796b] text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
+bg-gradient-to-br from-[#a7ddb8] to-[#d3f5e8] text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
 ```
 
 項目をクリックすると `notification_detail.html` に遷移し、

--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -6,14 +6,22 @@ body {
 /* グラデーションのヘッダーバー */
 .gradient-bar {
   /* ヘッダーの背景色は変数で上書き可能にする */
-  background: var(--header-bg, linear-gradient(135deg, #2c3e50 0%, #34495e 100%));
+  background: var(
+    --header-bg,
+    /* デフォルトは明るめのグラデーション */
+    linear-gradient(135deg, #a0e5ff 0%, #c4f1ff 100%)
+  );
   color: #fff;
 }
 
 /* 一覧のバー(リスト項目)に適用するスタイル */
 .notification-item {
   /* カードの色は CSS 変数から取得し、内容に応じて変更できるようにする */
-  background-color: var(--item-color, #49796b);
+  background: var(
+    --item-bg,
+    /* デフォルトはヘッダーに合わせた淡いグラデーション */
+    linear-gradient(135deg, #a7ddb8 0%, #d3f5e8 100%)
+  );
   color: #fff;
   padding: 1rem;
   border-radius: 0.75rem;

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -14,8 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
         '具体的には以下の項目を調査：\n\n' +
         '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
         'これら4項目の平均値が「消費者態度指数」として発表されます。',
-      // 一覧で使う色を登録
-      color: '#49796b'
+      // 一覧で使うグラデーションを登録
+      color: 'linear-gradient(135deg, #a7ddb8 0%, #d3f5e8 100%)'
     });
     localStorage.setItem('notifications', JSON.stringify(saved));
   }
@@ -26,9 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const li = document.createElement('li');
     // デザイン用クラスを付与
     li.className = 'notification-item cursor-pointer';
-    // 内容に応じた色を設定
+    // 内容に応じた背景を設定
     if (msg.color) {
-      li.style.setProperty('--item-color', msg.color);
+      li.style.setProperty('--item-bg', msg.color);
     }
     li.innerHTML = `<p class="font-semibold">${msg.title}</p>`;
     li.addEventListener('click', () => {


### PR DESCRIPTION
## 変更内容
- 通知一覧のバーを淡いグラデーションに変更
- デフォルト通知の背景もグラデーションに
- README の説明を更新

## テスト結果
- `npm install`
- `npm test` すべて成功

------
https://chatgpt.com/codex/tasks/task_e_6850f2a4ab80832c8fd4435e21e8d1ba