### PR TITLE
fix: 通知詳細の読み込み時エラー処理追加

### DIFF
--- a/public/notification_detail.js
+++ b/public/notification_detail.js
@@ -4,7 +4,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const index = parseInt(params.get('index'), 10);
-  const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+  // localStorage から通知リストを取得します
+  // データ取得時のエラーに備えて try...catch で囲みます
+  let saved = [];
+  try {
+    // 保存されていなければ空配列を使います
+    saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+  } catch (e) {
+    // JSON 解析に失敗した場合はエラーを出力しますが、空配列のまま処理を続けます
+    console.error(e);
+  }
   const msg = saved[index] || { title: '不明', body: '', color: '#49796b' };
 
   // タイトルと本文を表示


### PR DESCRIPTION
## 変更内容
- `public/notification_detail.js` で `localStorage` 読み込みを `try...catch` で包み、失敗時は空配列のまま続行するよう修正

## 動作確認
- `npm test` を実行し、既存テストが全て成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_6850f731a4d8832ca4c1505deeb00ba9