### PR TITLE
通知データの共通ユーティリティ追加

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -93,19 +93,12 @@
 
   // お知らせメッセージ一覧を保持
   const [messages, setMessages] = useState(() => {
-    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
-    if (saved.length === 0) {
-      saved.push({
-        title: '消費者信頼感指数調査のお知らせ',
-        body:
-          '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
-          '具体的には以下の項目を調査：\n\n' +
-          '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
-          'これら4項目の平均値が「消費者態度指数」として発表されます。',
-        color: '#49796b'
-      });
-      localStorage.setItem('notifications', JSON.stringify(saved));
+    // ユーティリティが利用可能ならそこから取得
+    if (typeof loadNotifications === 'function') {
+      return loadNotifications();
     }
+    // Fallback: 直接ローカルストレージから取得
+    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
     return saved;
   });
 

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -15,6 +15,8 @@
   <link rel="stylesheet" href="globals.css" />
   <link rel="stylesheet" href="game_screen.css" />
   <!-- React用コンポーネントを読み込み -->
+  <!-- お知らせ機能の共通ユーティリティ -->
+  <script defer src="notification_utils.js"></script>
   <script defer src="components/Sparkline.js"></script>
   <script defer src="components/GameImpactList.js"></script>
   <script defer src="components/IndicatorDetailModal.js"></script>

--- a/public/notification_utils.js
+++ b/public/notification_utils.js
@@ -1,0 +1,35 @@
+(function () {
+  // デフォルトのお知らせ一覧を返す関数
+  function getDefaultNotifications() {
+    return [
+      {
+        title: '消費者信頼感指数調査のお知らせ',
+        body:
+          '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
+          '具体的には以下の項目を調査：\n\n' +
+          '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
+          'これら4項目の平均値が「消費者態度指数」として発表されます。',
+        color: '#49796b'
+      }
+    ];
+  }
+
+  // ローカルストレージから通知を取得し、無ければデフォルトを保存して返す
+  function loadNotifications() {
+    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
+    if (saved.length === 0) {
+      const defaults = getDefaultNotifications();
+      saved.push(...defaults);
+      localStorage.setItem('notifications', JSON.stringify(saved));
+    }
+    return saved;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getDefaultNotifications, loadNotifications };
+  }
+  if (typeof window !== 'undefined') {
+    window.getDefaultNotifications = getDefaultNotifications;
+    window.loadNotifications = loadNotifications;
+  }
+})();

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -15,7 +15,8 @@
   </header>
   <!-- メッセージを表示するリスト -->
   <ul id="notificationList"></ul>
-  <!-- 一覧表示用のスクリプト -->
+  <!-- 共通ユーティリティと一覧表示用スクリプト -->
+  <script src="notification_utils.js"></script>
   <script src="notifications.js"></script>
 </body>
 </html>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -2,23 +2,11 @@
 // ローカルストレージからメッセージを読み込み、一覧を表示します
 
 document.addEventListener('DOMContentLoaded', () => {
-  // 保存済みメッセージを取得（無ければ空配列）
-  const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
-
-  // 初回表示時のみデフォルトメッセージを登録
-  if (saved.length === 0) {
-    saved.push({
-      title: '消費者信頼感指数調査のお知らせ',
-      body:
-        '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
-        '具体的には以下の項目を調査：\n\n' +
-        '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
-        'これら4項目の平均値が「消費者態度指数」として発表されます。',
-      // 一覧で使う色を登録
-      color: '#49796b'
-    });
-    localStorage.setItem('notifications', JSON.stringify(saved));
-  }
+  // 共通ユーティリティがあればそれを利用して通知を取得
+  const saved =
+    typeof loadNotifications === 'function'
+      ? loadNotifications()
+      : JSON.parse(localStorage.getItem('notifications') || '[]');
 
   const list = document.getElementById('notificationList');
   // 各メッセージをリストに追加


### PR DESCRIPTION
## Summary
- add `notification_utils.js` to share default notifications
- use the utility in `notifications.js` and GameScreen component
- load the new script on pages that need notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f9600b1c832cb2848a968dd3e532