### PR TITLE
通知データにIDを導入

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -478,15 +478,15 @@
         React.createElement(
           'ul',
           { className: 'space-y-4 list-none', id: 'notificationListReact' },
-          messages.map((msg, idx) =>
+          messages.map((msg) =>
             React.createElement(
               'li',
               {
-                key: idx,
+                key: msg.id,
                 className:
                   'bg-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400 cursor-pointer',
                 onClick: () => {
-                  window.location.href = `notification_detail.html?index=${idx}`;
+                  window.location.href = `notification_detail.html?id=${encodeURIComponent(msg.id)}`;
                 }
               },
               React.createElement('p', { className: 'font-semibold' }, msg.title)

--- a/public/notification_detail.js
+++ b/public/notification_detail.js
@@ -1,9 +1,9 @@
 // お知らせ詳細画面用スクリプト
-// URL パラメータからメッセージのインデックスを取得し、内容を表示します
+// URL パラメータから通知IDを取得し、該当通知を表示します
 
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
-  const index = parseInt(params.get('index'), 10);
+  const id = params.get('id');
   // localStorage から通知リストを取得します
   // データ取得時のエラーに備えて try...catch で囲みます
   let saved = [];
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // JSON 解析に失敗した場合はエラーを出力しますが、空配列のまま処理を続けます
     console.error(e);
   }
-  const msg = saved[index] || { title: '不明', body: '', color: '#49796b' };
+  const msg = saved.find((n) => n.id === id) || { title: '不明', body: '', color: '#49796b' };
 
   // タイトルと本文を表示
   document.getElementById('detailTitle').textContent = msg.title;

--- a/public/notification_utils.js
+++ b/public/notification_utils.js
@@ -1,28 +1,51 @@
 (function () {
+  // ランダムなIDを生成する簡易関数
+  function generateId() {
+    return 'n_' + Math.random().toString(36).slice(2, 9);
+  }
+
   // デフォルトのお知らせ一覧を返す関数
+  // id と作成日時、既読フラグを付与して返します
   function getDefaultNotifications() {
     return [
       {
+        id: generateId(),
         title: '消費者信頼感指数調査のお知らせ',
         body:
           '調査対象：全国から8,400世帯を選定し、調査への協力をお願いしています\n' +
           '具体的には以下の項目を調査：\n\n' +
           '暮らし向き\n収入の増え方\n雇用環境\n耐久消費財の買い時判断\n\n' +
           'これら4項目の平均値が「消費者態度指数」として発表されます。',
-        color: '#49796b'
+        color: '#49796b',
+        createdAt: new Date().toISOString(),
+        read: false
       }
     ];
   }
 
   // ローカルストレージから通知を取得し、無ければデフォルトを保存して返す
   function loadNotifications() {
-    const saved = JSON.parse(localStorage.getItem('notifications') || '[]');
-    if (saved.length === 0) {
+    const stored = JSON.parse(localStorage.getItem('notifications') || '[]');
+
+    // 保存データがなければデフォルトを生成
+    if (stored.length === 0) {
       const defaults = getDefaultNotifications();
-      saved.push(...defaults);
-      localStorage.setItem('notifications', JSON.stringify(saved));
+      localStorage.setItem('notifications', JSON.stringify(defaults));
+      return defaults;
     }
-    return saved;
+
+    // フィールドが不足している場合は補完
+    const updated = stored.map((n) => ({
+      id: n.id || generateId(),
+      title: n.title,
+      body: n.body,
+      color: n.color,
+      createdAt: n.createdAt || new Date().toISOString(),
+      read: typeof n.read === 'boolean' ? n.read : false
+    }));
+
+    localStorage.setItem('notifications', JSON.stringify(updated));
+    return updated;
   }
 
   if (typeof module !== 'undefined' && module.exports) {

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const list = document.getElementById('notificationList');
   // 各メッセージをリストに追加
-  saved.forEach((msg, idx) => {
+  saved.forEach((msg) => {
     const li = document.createElement('li');
     // デザイン用クラスを付与
     li.className = 'notification-item cursor-pointer';
@@ -24,8 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
     title.textContent = msg.title;
     li.appendChild(title);
     li.addEventListener('click', () => {
-      // 詳細画面へ遷移するときはインデックスをクエリパラメータで渡す
-      window.location.href = `notification_detail.html?index=${idx}`;
+      // id をクエリパラメータとして詳細ページへ
+      window.location.href = `notification_detail.html?id=${encodeURIComponent(msg.id)}`;
     });
     list.appendChild(li);
   });


### PR DESCRIPTION
## 概要
通知オブジェクトの形式を `{ id, title, body, color, createdAt, read }` に拡張し、初期データ生成時に各値を付与しました。また、一覧画面・詳細画面共に通知IDで取得するよう修正しています。

## 主な変更点
- `notification_utils.js` にID生成関数を追加し、保存処理をアップデート
- `notifications.js` で詳細画面への遷移にIDを使用
- `notification_detail.js` でIDから通知を検索して表示
- React 版 `GameScreen.js` も同様にIDで詳細へ遷移

## 使い方
`npm start` でサーバーを起動し、`/notifications.html` からお知らせ一覧を確認できます。各項目をクリックすると `notification_detail.html` に遷移し、対応する内容が表示されます。


------
https://chatgpt.com/codex/tasks/task_e_6850fa6ef960832c95a874fe01d74d9d