### PR TITLE
お知らせ詳細でReactアンケート実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ bg-[#49796b] text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
 ```
 
 項目をクリックすると `notification_detail.html` に遷移し、
-本文を確認して簡易フォームから返信できます。
+本文を確認したあと簡単なアンケートに回答できます。回答内容はブラウザに保存されます。
 
 ---
 

--- a/public/components/SurveyForm.js
+++ b/public/components/SurveyForm.js
@@ -1,0 +1,66 @@
+(function () {
+  // React の useState フックを使えるように取り出します
+  const { useState } = React;
+
+  // SurveyForm コンポーネント
+  // 質問文と選択肢を表示し、選択結果を保存します
+  function SurveyForm({ question, options, storageKey }) {
+    // どの選択肢が選ばれているかを状態として保持
+    const [selected, setSelected] = useState('');
+
+    // ラジオボタンが変化したときの処理
+    const handleChange = (e) => {
+      setSelected(e.target.value);
+    };
+
+    // 送信ボタンを押したときの処理
+    const handleSubmit = () => {
+      if (!selected) {
+        alert('回答を選択してください');
+        return;
+      }
+      // 選択結果を localStorage に保存
+      if (storageKey) {
+        localStorage.setItem(storageKey, selected);
+      }
+      // 保存した内容を簡易的に通知
+      alert(`回答を送信しました: ${selected}`);
+    };
+
+    return React.createElement(
+      'div',
+      { className: 'bg-white p-4 rounded-lg shadow space-y-4' },
+      // 質問文を表示
+      React.createElement('p', { className: 'font-semibold' }, question),
+      // 選択肢をラジオボタンで一覧表示
+      options.map((opt) =>
+        React.createElement(
+          'label',
+          { key: opt, className: 'flex items-center space-x-2' },
+          React.createElement('input', {
+            type: 'radio',
+            name: 'survey',
+            value: opt,
+            checked: selected === opt,
+            onChange: handleChange,
+          }),
+          React.createElement('span', null, opt)
+        )
+      ),
+      // 送信ボタン
+      React.createElement(
+        'button',
+        { className: 'mt-2 bg-blue-500 text-white px-4 py-1 rounded', onClick: handleSubmit },
+        '送信'
+      )
+    );
+  }
+
+  // モジュールとしてもブラウザからも使えるようエクスポート
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { SurveyForm };
+  }
+  if (typeof window !== 'undefined') {
+    window.SurveyForm = SurveyForm;
+  }
+})();

--- a/public/notification_detail.html
+++ b/public/notification_detail.html
@@ -15,11 +15,15 @@
     </div>
     <div class="detail-content">
       <p id="detailBody" class="whitespace-pre-wrap mb-4"></p>
-      <!-- 回答入力欄 -->
-      <textarea id="answer" rows="4" placeholder="ここに回答を入力"></textarea>
-      <button id="sendBtn">送信</button>
+      <!-- React でアンケートフォームを描画するエリア -->
+      <div id="surveyRoot"></div>
     </div>
   </div>
-  <script src="notification_detail.js"></script>
+  <!-- React のライブラリ読み込み -->
+  <script src="libs/react.production.min.js"></script>
+  <script src="libs/react-dom.production.min.js"></script>
+  <!-- アンケート用コンポーネント -->
+  <script defer src="components/SurveyForm.js"></script>
+  <script defer src="notification_detail.js"></script>
 </body>
 </html>

--- a/public/notification_detail.js
+++ b/public/notification_detail.js
@@ -14,7 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // JSON 解析に失敗した場合はエラーを出力しますが、空配列のまま処理を続けます
     console.error(e);
   }
-  const msg = saved.find((n) => n.id === id) || { title: '不明', body: '', color: '#49796b' };
+  const msg =
+    saved.find((n) => n.id === id) ||
+    { title: '不明', body: '', color: '#49796b' };
 
   // タイトルと本文を表示
   document.getElementById('detailTitle').textContent = msg.title;
@@ -25,8 +27,17 @@ document.addEventListener('DOMContentLoaded', () => {
     header.style.setProperty('--header-bg', msg.color);
   }
 
-  // 送信ボタンは簡易的にアラートを表示
-  document.getElementById('sendBtn').addEventListener('click', () => {
-    alert('回答を送信しました');
-  });
+  // アンケートフォームを表示
+  const root = document.getElementById('surveyRoot');
+  if (root && window.SurveyForm && window.ReactDOM && window.React) {
+    const question = 'このお知らせは役に立ちましたか？';
+    const options = ['はい', 'いいえ', 'どちらとも言えない'];
+    ReactDOM.createRoot(root).render(
+      React.createElement(SurveyForm, {
+        question,
+        options,
+        storageKey: `survey_${id}`,
+      })
+    );
+  }
 });


### PR DESCRIPTION
## 変更点
- React製 `SurveyForm` コンポーネントを追加
- `notification_detail.html` でアンケート表示用の領域とReact依存を読み込み
- `notification_detail.js` で通知詳細表示後にアンケートを描画
- README にアンケート回答可能な旨を追記

## 使い方
お知らせ一覧から項目をクリックすると詳細ページが開きます。本文下部に表示されるアンケートを選択して「送信」を押すと、選んだ内容がブラウザに保存されます。

------
https://chatgpt.com/codex/tasks/task_e_6850fdc91c50832ca6989d2635d95b23