### PR TITLE
経済指標の初期値を更新

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -41,28 +41,35 @@
   function GameScreen() {
   // ゲーム内で扱う各種指標を状態としてまとめて保持
   const [stats, setStats] = useState({
+    // ゲーム開始時点の各種指標
     money: 0,
     cpi: 100,
-    unemp: 4.2,
-    gdp: 1.8,
-    rate: 0.0,
-    fx: 150.0,
+    // 完全失業率
+    unemp: 2.5,
+    // 実質GDP成長率（年率換算）
+    gdp: -0.7,
+    // 日銀政策金利
+    rate: 0.5,
+    // ドル/円レート
+    fx: 144.94,
     yield: 0.9,
     cci: 100,
-    pmi: 50,
+    // 製造業PMI
+    pmi: 49.4,
     debtGDP: -3.0,
     trade: 1200
   });
   // 指標ごとの履歴を保存
   const [historyMap, setHistoryMap] = useState({
+    // 履歴にも初期値を登録しておく
     cpi: [100],
-    unemp: [4.2],
-    gdp: [1.8],
-    rate: [0.0],
-    fx: [150.0],
+    unemp: [2.5],
+    gdp: [-0.7],
+    rate: [0.5],
+    fx: [144.94],
     yield: [0.9],
     cci: [100],
-    pmi: [50],
+    pmi: [49.4],
     debtGDP: [-3.0],
     trade: [1200]
   });
@@ -89,7 +96,8 @@
 
   const [demand, setDemand] = useState(5);
   const [supply, setSupply] = useState(5);
-  const [policyRate, setPolicyRate] = useState(0.0);
+  // 政策金利の初期値
+  const [policyRate, setPolicyRate] = useState(0.5);
 
   // お知らせメッセージ一覧を保持
   const [messages, setMessages] = useState(() => {

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -58,9 +58,9 @@
       <h2 class="text-xl font-bold mb-2">経済指標</h2>
       <ul class="space-y-1 font-mono list-none">
         <li>CPI: <span id="cpi">102.4</span></li>
-        <li>失業率: <span id="unemp">4.2</span>%</li>
-        <li>GDP成長率: <span id="gdp">1.8</span>%</li>
-        <li>政策金利: <span id="rate">1.2</span>%</li>
+        <li>失業率: <span id="unemp">2.5</span>%</li>
+        <li>GDP成長率: <span id="gdp">-0.7</span>%</li>
+        <li>政策金利: <span id="rate">0.5</span>%</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- ゲーム開始時の経済指標を最新数値に変更
- ポリシーレートの初期値も0.5%に
- HTMLモーダルの表示値を更新

## 変更内容
- `GameScreen.js` 内の初期ステータスと履歴を新しい値に
- `game_screen.html` の失業率・GDP成長率・政策金利を修正

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c2f5bbe8832c807d746ef292d103