### PR TITLE
通知一覧に選択モードを追加

### DIFF
--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -29,6 +29,19 @@ body {
   transition: transform 0.2s ease;
 }
 
+/* 選択用チェックボックス */
+.select-box {
+  margin-left: 0.5rem;
+}
+
+/* お気に入りを示す星マーク */
+.favorite-mark {
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  font-size: 1.25rem;
+}
+
 /* 最初と最後の要素だけ角を丸める */
 .notification-item:first-child {
   border-top-left-radius: 0.75rem;

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -10,11 +10,18 @@
 </head>
 <body class="bg-gray-100 min-h-screen p-4">
   <!-- タイトルバー -->
-  <header class="gradient-bar p-4 mb-4 text-center rounded-lg shadow">
+  <header class="gradient-bar p-4 mb-4 rounded-lg shadow flex items-center justify-between">
     <h1 class="text-xl font-bold">お知らせ一覧</h1>
+    <!-- 選択モード切り替えボタン -->
+    <button id="selectModeBtn" class="bg-blue-500 text-white px-3 py-1 rounded">選択</button>
   </header>
   <!-- メッセージを表示するリスト -->
   <ul id="notificationList" class="notification-list"></ul>
+  <!-- 一括操作用ボタン。選択中のみ表示する -->
+  <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">
+    <button id="bulkDelete" class="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+    <button id="bulkFavorite" class="bg-yellow-500 text-white px-4 py-2 rounded">お気に入り</button>
+  </div>
   <!-- 共通ユーティリティと一覧表示用スクリプト -->
   <script src="notification_utils.js"></script>
   <script src="notifications.js"></script>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -3,12 +3,51 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   // 共通ユーティリティがあればそれを利用して通知を取得
-  const saved =
+  let saved =
     typeof loadNotifications === 'function'
       ? loadNotifications()
       : JSON.parse(localStorage.getItem('notifications') || '[]');
 
   const list = document.getElementById('notificationList');
+  const selectBtn = document.getElementById('selectModeBtn');
+  const bulkActions = document.getElementById('bulkActions');
+  const bulkDelete = document.getElementById('bulkDelete');
+  const bulkFav = document.getElementById('bulkFavorite');
+
+  let selectionMode = false;
+  const selected = new Set();
+
+  function updateStorage() {
+    localStorage.setItem('notifications', JSON.stringify(saved));
+  }
+
+  function updateBulkVisibility() {
+    if (!bulkActions) return;
+    if (selected.size > 0 && selectionMode) {
+      bulkActions.classList.remove('hidden');
+    } else {
+      bulkActions.classList.add('hidden');
+    }
+  }
+
+  function toggleSelectionMode() {
+    selectionMode = !selectionMode;
+    if (selectBtn) {
+      selectBtn.textContent = selectionMode ? 'キャンセル' : '選択';
+    }
+    selected.clear();
+    // チェックボックス表示切替
+    document.querySelectorAll('.select-box').forEach((cb) => {
+      cb.checked = false;
+      cb.classList.toggle('hidden', !selectionMode);
+    });
+    updateBulkVisibility();
+  }
+
+  if (selectBtn) {
+    selectBtn.addEventListener('click', toggleSelectionMode);
+  }
+
   // 各メッセージをリストに追加
   saved.forEach((msg) => {
     const li = document.createElement('li');
@@ -20,9 +59,31 @@ document.addEventListener('DOMContentLoaded', () => {
       li.style.setProperty('--item-color', msg.color);
     }
 
+    // お気に入りマーク
+    if (msg.favorite) {
+      const star = document.createElement('span');
+      star.textContent = '★';
+      star.className = 'favorite-mark';
+      li.appendChild(star);
+    }
+
     // スワイプ用のラッパーを用意
     const wrapper = document.createElement('div');
-    wrapper.className = 'relative';
+    wrapper.className = 'relative flex items-center';
+
+    // 選択用チェックボックス
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'select-box hidden';
+    checkbox.dataset.id = msg.id;
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        selected.add(msg.id);
+      } else {
+        selected.delete(msg.id);
+      }
+      updateBulkVisibility();
+    });
 
     // 通知の内容部分
     const content = document.createElement('div');
@@ -37,8 +98,13 @@ document.addEventListener('DOMContentLoaded', () => {
     delBtn.className = 'delete-btn';
     delBtn.textContent = '削除';
 
-    // 詳細画面へ遷移
+    // 詳細画面へ遷移または選択
     content.addEventListener('click', () => {
+      if (selectionMode) {
+        checkbox.checked = !checkbox.checked;
+        checkbox.dispatchEvent(new Event('change'));
+        return;
+      }
       if (!content.classList.contains('opened')) {
         window.location.href = `notification_detail.html?id=${encodeURIComponent(msg.id)}`;
       }
@@ -57,24 +123,26 @@ document.addEventListener('DOMContentLoaded', () => {
     let diffX;
 
     const handleEnd = () => {
+      if (selectionMode) return;
       content.style.transition = 'transform 0.2s ease';
       if (diffX < -30) {
         content.style.transform = 'translateX(-60px)';
         content.classList.add('opened');
-        } else {
+      } else {
         content.style.transform = '';
         content.classList.remove('opened');
-        }
+      }
       startX = null;
     };
 
     content.addEventListener('pointerdown', (e) => {
+      if (selectionMode) return;
       startX = e.clientX;
       diffX = 0;
       content.style.transition = 'none';
     });
     content.addEventListener('pointermove', (e) => {
-      if (startX == null) return;
+      if (selectionMode || startX == null) return;
       diffX = e.clientX - startX;
       if (diffX < 0) {
         content.style.transform = `translateX(${Math.max(diffX, -60)}px)`;
@@ -83,9 +151,45 @@ document.addEventListener('DOMContentLoaded', () => {
     content.addEventListener('pointerup', handleEnd);
     content.addEventListener('pointercancel', handleEnd);
 
+    wrapper.appendChild(checkbox);
     wrapper.appendChild(content);
     wrapper.appendChild(delBtn);
     li.appendChild(wrapper);
     list.appendChild(li);
+  });
+
+  // 一括削除処理
+  if (bulkDelete) bulkDelete.addEventListener('click', () => {
+    saved = saved.filter((n) => !selected.has(n.id));
+    updateStorage();
+    // DOMから該当要素を削除
+    document.querySelectorAll('.select-box').forEach((cb) => {
+      if (selected.has(cb.dataset.id)) {
+        cb.closest('li').remove();
+      }
+    });
+    selected.clear();
+    updateBulkVisibility();
+  });
+
+  // お気に入り登録処理
+  if (bulkFav) bulkFav.addEventListener('click', () => {
+    saved = saved.map((n) =>
+      selected.has(n.id) ? { ...n, favorite: true } : n
+    );
+    updateStorage();
+    document.querySelectorAll('.select-box').forEach((cb) => {
+      if (selected.has(cb.dataset.id)) {
+        const star = cb.closest('li').querySelector('.favorite-mark');
+        if (!star) {
+          const s = document.createElement('span');
+          s.textContent = '★';
+          s.className = 'favorite-mark';
+          cb.closest('li').appendChild(s);
+        }
+      }
+    });
+    selected.clear();
+    updateBulkVisibility();
   });
 });


### PR DESCRIPTION
## 変更内容
- お知らせ一覧のヘッダーに「選択」ボタンを追加
- 選択モード中にチェックボックスで複数の通知を選択可能に
- 選択した通知に対する一括削除・お気に入り登録機能を実装
- お気に入りマークやチェックボックス表示用のスタイルを追加
- テストを実行し全て成功することを確認

## 使い方
1. `notifications.html` をブラウザで開く
2. 右上の「選択」を押すとチェックボックスが現れ通知を選択可能
3. 選択後に画面下部の「削除」「お気に入り」ボタンで一括操作できる


------
https://chatgpt.com/codex/tasks/task_e_6858ee3e9e18832c8a184af8385d6248