### PR TITLE
通知リストUIをiOS風にリファイン

### DIFF
--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -20,11 +20,11 @@ body {
 
 /* 各通知アイテムの基本スタイル */
 .notification-item {
-  background-color: var(--item-color, #49796b);
+  /* 背景色は親要素に任せ、境界線は divide-y で付ける */
+  background-color: transparent;
   color: #fff;
   position: relative;
   overflow: hidden;
-  border-bottom: 4px solid #333;
   margin: 0;
   transition: transform 0.2s ease;
 }
@@ -43,20 +43,12 @@ body {
 }
 
 /* 最初と最後の要素だけ角を丸める */
-.notification-item:first-child {
-  border-top-left-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-}
 
-.notification-item:last-child {
-  border-bottom-left-radius: 0.75rem;
-  border-bottom-right-radius: 0.75rem;
-  border-bottom: none;
-}
+/* 角丸は ul 要素側でまとめて指定するためここでは不要 */
 
 /* 通知内容部分。スワイプ時に左右へ動かす */
 .item-content {
-  padding: 1rem;
+  /* パディングは Tailwind クラス側で指定する */
   transition: transform 0.2s ease;
 }
 

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gray-100 min-h-screen p-4">
+<body class="bg-gradient-to-b from-[#1a1a2f] to-[#2d2d4a] min-h-screen p-4">
   <!-- タイトルバー -->
   <header class="gradient-bar p-4 mb-4 rounded-lg shadow flex items-center justify-between">
     <h1 class="text-xl font-bold">お知らせ一覧</h1>
@@ -16,7 +16,10 @@
     <button id="selectModeBtn" class="bg-blue-500 text-white px-3 py-1 rounded">選択</button>
   </header>
   <!-- メッセージを表示するリスト -->
-  <ul id="notificationList" class="notification-list"></ul>
+  <ul
+    id="notificationList"
+    class="notification-list rounded-xl divide-y divide-gray-600 bg-gray-800 overflow-hidden"
+  ></ul>
   <!-- 一括操作用ボタン。選択中のみ表示する -->
   <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">
     <button id="bulkDelete" class="bg-red-500 text-white px-4 py-2 rounded">削除</button>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -87,11 +87,41 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 通知の内容部分
     const content = document.createElement('div');
-    content.className = 'item-content cursor-pointer';
+    content.className = 'item-content cursor-pointer flex flex-col p-3';
+
+    // ヘッダー行（タイトル、日付、未読アイコン）
+    const headerRow = document.createElement('div');
+    headerRow.className = 'flex justify-between items-start';
+
+    // 未読アイコン
+    if (!msg.read) {
+      const icon = document.createElement('span');
+      icon.textContent = '📩';
+      icon.className = 'mr-2';
+      headerRow.appendChild(icon);
+    }
+
     const title = document.createElement('p');
-    title.className = 'font-semibold';
+    title.className = 'font-semibold text-sm text-white flex-1';
     title.textContent = msg.title;
-    content.appendChild(title);
+    headerRow.appendChild(title);
+
+    const date = document.createElement('p');
+    date.className = 'text-xs text-gray-500';
+    try {
+      date.textContent = new Date(msg.createdAt).toLocaleDateString('ja-JP');
+    } catch (e) {
+      date.textContent = '';
+    }
+    headerRow.appendChild(date);
+
+    content.appendChild(headerRow);
+
+    // 本文
+    const body = document.createElement('p');
+    body.className = 'text-xs text-gray-300 mt-1';
+    body.textContent = msg.body || '';
+    content.appendChild(body);
 
     // 削除ボタン
     const delBtn = document.createElement('button');


### PR DESCRIPTION
## 変更内容
- お知らせ一覧の背景をグラデーションに変更
- 通知リストを角丸コンテナ化し、`divide-y` で区切り線を実装
- 各通知にタイトル・本文・日付を表示し、未読アイコンを追加
- CSS を整理し、角丸や余白の指定をTailwindに合わせて修正

## 使い方
1. `npm start` で `http://localhost:8080/notifications.html` を開きます。
2. 一覧はiOS風のデザインで表示され、未読には📩アイコンが付きます。
3. タップで詳細ページへ遷移します。

## テスト
- `npm test` を実行し、既存6件のテストがすべて成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6858f5375bd4832cbaec3bba213176f0