### PR TITLE
お知らせ一覧のUIをiOS風に刷新

### DIFF
--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -20,13 +20,11 @@ body {
 
 /* 各通知アイテムの基本スタイル */
 .notification-item {
-  background-color: var(--item-color, #49796b);
-  color: #fff;
   position: relative;
   overflow: hidden;
-  border-bottom: 4px solid #333;
   margin: 0;
-  transition: transform 0.2s ease;
+  transition: background-color 0.2s ease;
+  color: #fff;
 }
 
 /* 選択用チェックボックス */
@@ -43,16 +41,7 @@ body {
 }
 
 /* 最初と最後の要素だけ角を丸める */
-.notification-item:first-child {
-  border-top-left-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-}
 
-.notification-item:last-child {
-  border-bottom-left-radius: 0.75rem;
-  border-bottom-right-radius: 0.75rem;
-  border-bottom: none;
-}
 
 /* 通知内容部分。スワイプ時に左右へ動かす */
 .item-content {
@@ -80,8 +69,7 @@ body {
 }
 
 .notification-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* 詳細画面のコンテナ */

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gray-100 min-h-screen p-4">
+<body class="bg-gradient-to-b from-[#1a1a2f] to-[#2d2d4a] min-h-screen p-4">
   <!-- タイトルバー -->
   <header class="gradient-bar p-4 mb-4 rounded-lg shadow flex items-center justify-between">
     <h1 class="text-xl font-bold">お知らせ一覧</h1>
@@ -16,7 +16,10 @@
     <button id="selectModeBtn" class="bg-blue-500 text-white px-3 py-1 rounded">選択</button>
   </header>
   <!-- メッセージを表示するリスト -->
-  <ul id="notificationList" class="notification-list"></ul>
+  <ul
+    id="notificationList"
+    class="notification-list bg-gray-800 rounded-xl divide-y divide-gray-600"
+  ></ul>
   <!-- 一括操作用ボタン。選択中のみ表示する -->
   <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">
     <button id="bulkDelete" class="bg-red-500 text-white px-4 py-2 rounded">削除</button>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -55,9 +55,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (msg.read) {
       li.classList.add('read-notification');
     }
-    if (msg.color) {
-      li.style.setProperty('--item-color', msg.color);
-    }
 
     // お気に入りマーク
     if (msg.favorite) {
@@ -87,11 +84,38 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 通知の内容部分
     const content = document.createElement('div');
-    content.className = 'item-content cursor-pointer';
+    // 通知テキスト全体をまとめる要素
+    content.className = 'item-content cursor-pointer flex flex-col space-y-1';
+
+    // タイトル行を作成
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'flex items-start justify-between';
+
+    // 未読アイコン
+    if (!msg.read) {
+      const icon = document.createElement('span');
+      icon.textContent = '📩';
+      icon.className = 'mr-2';
+      titleWrap.appendChild(icon);
+    }
+
     const title = document.createElement('p');
-    title.className = 'font-semibold';
+    title.className = 'font-semibold text-sm text-white flex-1';
     title.textContent = msg.title;
-    content.appendChild(title);
+    titleWrap.appendChild(title);
+
+    const date = document.createElement('p');
+    date.className = 'text-xs text-gray-500';
+    date.textContent = new Date(msg.createdAt).toLocaleDateString('ja-JP');
+    titleWrap.appendChild(date);
+
+    content.appendChild(titleWrap);
+
+    const body = document.createElement('p');
+    body.className = 'text-xs text-gray-300';
+    body.textContent =
+      msg.body.length > 40 ? msg.body.slice(0, 40) + '…' : msg.body;
+    content.appendChild(body);
 
     // 削除ボタン
     const delBtn = document.createElement('button');


### PR DESCRIPTION
## 変更点
- `notifications.html` の背景をグラデーションに変更し、通知リストに `divide-y` を適用
- `notification_style.css` を整理し、カード風の余白や角丸を廃止
- `notifications.js` でタイトル・本文・日付を表示し、未読アイコンを追加

## 使い方
1. `npm install` で依存パッケージを入れる
2. `npm test` でテスト実行
3. `public/notifications.html` をブラウザで開くと新しいデザインの通知一覧を確認できます

------
https://chatgpt.com/codex/tasks/task_e_6858f5375bd4832cbaec3bba213176f0