### PR TITLE
通知画面の背景スタイル調整

### DIFF
--- a/public/notification_detail.html
+++ b/public/notification_detail.html
@@ -8,7 +8,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gray-100 min-h-screen">
+  <!-- 一覧画面と同じ暗めのグラデーション背景に変更 -->
+  <body class="bg-gradient-to-b from-[#1a1a2f] to-[#2d2d4a] min-h-screen p-4">
   <div class="detail-container">
     <div class="gradient-bar detail-header">
       <h1 id="detailTitle" class="text-xl font-bold"></h1>

--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -6,7 +6,11 @@ body {
 /* グラデーションのヘッダーバー */
 .gradient-bar {
   /* ヘッダーの背景色は変数で上書き可能にする */
-  background: var(--header-bg, linear-gradient(135deg, #2c3e50 0%, #34495e 100%));
+  /* game_screen のヘッダーと同じグラデーションカラーを採用 */
+  background: var(
+    --header-bg,
+    linear-gradient(to right, #111827 0%, #1f2937 50%, rgba(17, 24, 39, 0.9) 100%)
+  );
   color: #fff;
 }
 


### PR DESCRIPTION
## 概要
- `notification_detail.html` のbody背景を通知一覧と同じ暗めグラデーションに統一しました
- ヘッダーバー(`gradient-bar`)のデフォルト色をゲーム画面と同じグラデーションに変更しました

## 使い方
お知らせ詳細ページを開くと、背景が一覧ページと同じ雰囲気になり、ヘッダーはゲーム画面と同じ配色で表示されます。

## テスト
- `npm test` を実行し全テストが成功することを確認済み


------
https://chatgpt.com/codex/tasks/task_e_68595e964884832c987b2625719a053f