### PR TITLE
通知リストの配色調整

### DIFF
--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -16,12 +16,22 @@ body {
   list-style: none;
   padding: 0;
   margin: 0;
+  /*
+    背景色も変数で指定し、デフォルトは薄いベージュ系にします。
+    Tailwind の divide クラスの色と合わせるため、境界線色も変数で
+    上書きできるようにします。
+  */
+  background-color: var(--list-bg, #f7f5f1);
+  border-color: var(--list-border, #e0dcd6);
 }
 
 /* 各通知アイテムの基本スタイル */
 .notification-item {
-  /* 背景色は親要素に任せ、境界線は divide-y で付ける */
-  background-color: transparent;
+  /*
+    各通知カードの背景色を変数で上書きできるようにします。
+    指定がない場合は経済指数カードと同じ色を使います。
+  */
+  background-color: var(--item-color, #f7f5f1);
   color: #fff;
   position: relative;
   overflow: hidden;

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -18,7 +18,7 @@
   <!-- メッセージを表示するリスト -->
   <ul
     id="notificationList"
-    class="notification-list rounded-xl divide-y divide-gray-600 bg-gray-800 overflow-hidden"
+    class="notification-list rounded-xl divide-y divide-[#e0dcd6] bg-[#f7f5f1] overflow-hidden"
   ></ul>
   <!-- 一括操作用ボタン。選択中のみ表示する -->
   <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">


### PR DESCRIPTION
## 変更内容
- `.notification-item` に背景色のCSS変数を追加し、デフォルトを `#f7f5f1` に設定
- `.notification-list` に背景色と境界線色を追加
- `notifications.html` 側のクラスも新しい色に合わせて更新

## 動作確認
- `npm test` を実行し、全テストが成功することを確認済み


------
https://chatgpt.com/codex/tasks/task_e_6859e259bec0832c89e5a1fd9501d239