### PR TITLE
通知デモの追加

### DIFF
--- a/public/notification_utils.js
+++ b/public/notification_utils.js
@@ -19,6 +19,16 @@
         color: '#49796b',
         createdAt: new Date().toISOString(),
         read: false
+      },
+      {
+        id: generateId(),
+        title: '価格高騰重点支援給付金のお知らせ',
+        body:
+          '価格高騰の影響を受けた世帯に向けた給付金の申請受付が開始されました。' +
+          '\n詳細はお住まいの市区町村の窓口までお問い合わせください。',
+        color: '#49796b',
+        createdAt: new Date().toISOString(),
+        read: false
       }
     ];
   }

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -40,6 +40,9 @@ describe('notifications localStorage and detail view', () => {
     expect(stored).not.toBeNull();
     expect(stored.length).toBeGreaterThan(0);
     expect(stored[0].title).toBe('消費者信頼感指数調査のお知らせ');
+    // 2件目のお知らせも存在するか確認
+    expect(stored.length).toBeGreaterThan(1);
+    expect(stored[1].title).toBe('価格高騰重点支援給付金のお知らせ');
 
     const list = document.getElementById('notificationList');
     expect(list.children.length).toBe(stored.length);


### PR DESCRIPTION
## 概要
- 初期表示されるデモ通知に「価格高騰重点支援給付金のお知らせ」を追加
- テストを更新し新しい通知の存在を確認

## テスト
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f4843994832c9126ceba706a8e89