### PR TITLE
お知らせ画面を明るい配色に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@ npm test     # Jest でテストを実行
 
 
 `notifications.html` を開くと、ゲーム内で受け取ったお知らせを一覧できます。
-カード部分は #49796b 色の以下の Tailwind クラスを使ったシンプルなデザインです。
+背景は明るいグレー系に変更し、各通知カードも白背景で表示されます。
+主に次のような Tailwind クラスを用いています。
 
 ```
-bg-[#49796b] text-white shadow-lg rounded-xl p-4 border-l-4 border-blue-400
+bg-white text-gray-800 shadow-lg rounded-xl p-4 border-l-4 border-blue-400
 ```
 
 項目をクリックすると `notification_detail.html` に遷移し、

--- a/public/notification_detail.js
+++ b/public/notification_detail.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (msg.color) {
     const header = document.querySelector('.detail-header');
     header.style.setProperty('--header-bg', msg.color);
+    header.style.setProperty('--header-text', '#fff');
   }
 
   // アンケート送信後に既読フラグを更新して一覧へ戻る関数

--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -5,9 +5,9 @@ body {
 
 /* グラデーションのヘッダーバー */
 .gradient-bar {
-  /* ヘッダーの背景色は変数で上書き可能にする */
-  background: var(--header-bg, linear-gradient(135deg, #2c3e50 0%, #34495e 100%));
-  color: #fff;
+  /* ヘッダーの背景色と文字色を変数で上書き可能にする */
+  background: var(--header-bg, linear-gradient(135deg, #ffffff 0%, #e2e8f0 100%));
+  color: var(--header-text, #333);
 }
 
 /* 一覧のバー(リスト項目)に適用するスタイル */
@@ -21,8 +21,8 @@ body {
     Tailwind の divide クラスの色と合わせるため、境界線色も変数で
     上書きできるようにします。
   */
-  background-color: var(--list-bg, #f7f5f1);
-  border-color: var(--list-border, #e0dcd6);
+  background-color: var(--list-bg, #ffffff);
+  border-color: var(--list-border, #d1d5db);
 }
 
 /* 各通知アイテムの基本スタイル */
@@ -31,8 +31,8 @@ body {
     各通知カードの背景色を変数で上書きできるようにします。
     指定がない場合は経済指数カードと同じ色を使います。
   */
-  background-color: var(--item-color, #f7f5f1);
-  color: #fff;
+  background-color: var(--item-color, #ffffff);
+  color: var(--item-text, #333);
   position: relative;
   overflow: hidden;
   margin: 0;

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gradient-to-b from-[#1a1a2f] to-[#2d2d4a] min-h-screen p-4">
+<body class="bg-gray-50 min-h-screen p-4">
   <!-- タイトルバー -->
   <header class="gradient-bar p-4 mb-4 rounded-lg shadow flex items-center justify-between">
     <h1 class="text-xl font-bold">お知らせ一覧</h1>
@@ -18,7 +18,7 @@
   <!-- メッセージを表示するリスト -->
   <ul
     id="notificationList"
-    class="notification-list rounded-xl divide-y divide-[#e0dcd6] bg-[#f7f5f1] overflow-hidden"
+    class="notification-list rounded-xl divide-y divide-gray-300 bg-white overflow-hidden"
   ></ul>
   <!-- 一括操作用ボタン。選択中のみ表示する -->
   <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -55,9 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (msg.read) {
       li.classList.add('read-notification');
     }
-    if (msg.color) {
-      li.style.setProperty('--item-color', msg.color);
-    }
+    // カード背景色はデフォルトのまま使用します
 
     // お気に入りマーク
     if (msg.favorite) {
@@ -102,7 +100,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const title = document.createElement('p');
-    title.className = 'font-semibold text-sm text-white flex-1';
+    // タイトルは濃いめの文字色で表示
+    title.className = 'font-semibold text-sm text-gray-800 flex-1';
     title.textContent = msg.title;
     headerRow.appendChild(title);
 
@@ -119,7 +118,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 本文
     const body = document.createElement('p');
-    body.className = 'text-xs text-gray-300 mt-1';
+    // 本文も読みやすい色に変更
+    body.className = 'text-xs text-gray-600 mt-1';
     body.textContent = msg.body || '';
     content.appendChild(body);
 


### PR DESCRIPTION
## 概要
- `notifications.html` の背景を明るいグレーに変更し、リストも白背景へ
- `notification_style.css` でヘッダーや通知カードの標準色を白系に調整
- `notifications.js` でテキスト色を読みやすく修正
- `notification_detail.js` で個別通知のヘッダー色設定時に文字色も指定
- README のお知らせ画面説明を更新

## テスト
- `npm test` を実行したが `jest` が見つからず失敗


------
https://chatgpt.com/codex/tasks/task_e_685a015197f4832c8af52ef49ea676df