### PR TITLE
お知らせ一覧のボックスデザイン追加

### DIFF
--- a/public/notification_style.css
+++ b/public/notification_style.css
@@ -56,6 +56,23 @@ body {
   opacity: 0.6;
 }
 
+/*==================================================
+  新しい通知デザインボックス
+  .box4 クラスを追加
+==================================================*/
+.box4 {
+  padding: 8px 19px;
+  margin: 2em 0;
+  color: #2c2c2f;
+  background: #cde4ff;
+  border-top: solid 5px #5989cf;
+  border-bottom: solid 5px #5989cf;
+}
+.box4 p {
+  margin: 0;
+  padding: 0;
+}
+
 
 
 /* 詳細画面のコンテナ */

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="notification_style.css" />
 </head>
-<body class="bg-gradient-to-b from-[#28334a] to-[#1b2436] min-h-screen p-4 text-white">
+<body class="bg-gray-100 min-h-screen p-4 text-gray-800">
   <!-- タイトルバー -->
   <header class="mb-4 flex items-center justify-between">
     <h1 class="text-lg font-bold">📬 お知らせ一覧</h1>
@@ -16,10 +16,7 @@
     <button id="selectModeBtn" class="text-sm bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded">選択</button>
   </header>
   <!-- メッセージを表示するリスト -->
-  <ul
-    id="notificationList"
-    class="notification-list rounded-xl shadow-2xl divide-y divide-gray-600 bg-gradient-to-b from-[#28334a] to-[#1b2436] overflow-hidden"
-  ></ul>
+  <ul id="notificationList" class="notification-list"></ul>
   <!-- 一括操作用ボタン。選択中のみ表示する -->
   <div id="bulkActions" class="hidden fixed bottom-0 inset-x-0 bg-white border-t p-2 flex justify-center space-x-4">
     <button id="bulkDelete" class="bg-red-500 text-white px-4 py-2 rounded">削除</button>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 各メッセージをリストに追加
   saved.forEach((msg) => {
     const li = document.createElement('li');
-    li.className = 'notification-item hover:bg-[#39485f] transition-all duration-200';
+    li.className = 'notification-item box4';
     if (msg.read) {
       li.classList.add('read-notification');
     }
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const wrapper = document.createElement('div');
-    wrapper.className = 'relative flex items-start p-3';
+    wrapper.className = 'relative flex items-start';
 
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';


### PR DESCRIPTION
## 変更内容
- `notifications.html` の背景を明るいグレーに変更し、通知リストの装飾を簡素化
- `notification_style.css` に `.box4` クラスを追加して青枠付きのボックスデザインを定義
- `notifications.js` で各通知アイテムに `.box4` を適用

## テスト
- `npm install`
- `npm test` を実行し、6件のテストがすべて成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685a360d94a4832c8ee91aee97040069