### PR TITLE
ヘッダーコンポーネントの追加

### DIFF
--- a/public/components/EcoHeader.js
+++ b/public/components/EcoHeader.js
@@ -1,0 +1,87 @@
+(function () {
+  const { createElement } = React;
+
+  // 鐘のアイコンを描画するシンプルなコンポーネント
+  function Bell(props) {
+    return createElement(
+      'svg',
+      Object.assign(
+        { viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round' },
+        props
+      ),
+      createElement('path', { d: 'M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9' }),
+      createElement('path', { d: 'M13.73 21a2 2 0 0 1-3.46 0' })
+    );
+  }
+
+  // ECOBOX のヘッダー部分を表示するコンポーネント
+  function EcoHeader({ unreadCount = 0 }) {
+    return createElement(
+      'div',
+      { className: 'relative mb-8' },
+      // 背景とタイトル部分
+      createElement(
+        'div',
+        { className: 'bg-gradient-to-r from-slate-800 to-slate-700 rounded-t-xl p-6 border-b border-slate-600 shadow-2xl' },
+        createElement(
+          'div',
+          { className: 'flex items-center justify-between' },
+          // 左側: アイコンとタイトル
+          createElement(
+            'div',
+            { className: 'flex items-center space-x-4' },
+            createElement(
+              'div',
+              { className: 'relative' },
+              createElement(Bell, { className: 'w-8 h-8 text-cyan-400' }),
+              unreadCount > 0
+                ? createElement(
+                    'div',
+                    {
+                      className: 'absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center animate-pulse'
+                    },
+                    unreadCount
+                  )
+                : null
+            ),
+            createElement(
+              'h1',
+              { className: 'text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-blue-400 tracking-wider' },
+              'ECOBOX'
+            )
+          ),
+          // 右側: 日付と説明
+          createElement(
+            'div',
+            { className: 'text-sm text-slate-400' },
+            new Date().toLocaleDateString('ja-JP'),
+            ' | 経済情報端末'
+          )
+        ),
+        // サブテキスト
+        createElement(
+          'div',
+          { className: 'mt-2 text-slate-300 text-sm' },
+          `📈 経済・金融情報管理システム | 未読: ${unreadCount}件`
+        )
+      ),
+      // 通貨モチーフの装飾
+      createElement(
+        'div',
+        { className: 'absolute inset-0 opacity-5 pointer-events-none' },
+        createElement('div', { className: 'text-6xl text-green-400 absolute top-4 right-4' }, '¥'),
+        createElement('div', { className: 'text-4xl text-blue-400 absolute top-8 right-16' }, '$'),
+        createElement('div', { className: 'text-3xl text-yellow-400 absolute top-12 right-28' }, '€')
+      )
+    );
+  }
+
+  // モジュールエクスポート設定
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { EcoHeader, Bell };
+  }
+  if (typeof window !== 'undefined') {
+    window.EcoHeader = EcoHeader;
+    window.Bell = Bell;
+  }
+})();

--- a/public/ecobox.js
+++ b/public/ecobox.js
@@ -1,6 +1,13 @@
 (function () {
   // React のフックを取り出します
   const { useState } = React;
+  // EcoHeader コンポーネントを取得
+  let EcoHeader;
+  if (typeof require !== 'undefined') {
+    ({ EcoHeader } = require('./components/EcoHeader.js'));
+  } else if (typeof window !== 'undefined') {
+    EcoHeader = window.EcoHeader;
+  }
 
   // メインコンポーネント
   function EcoBoxUI() {
@@ -60,30 +67,7 @@
       'div',
       { className: 'p-4' },
       // ヘッダー
-      React.createElement(
-        'header',
-        { className: 'mb-6 flex items-center justify-between' },
-        React.createElement(
-          'h1',
-          { className: 'text-2xl font-bold flex items-center' },
-          '🔔 ECOBOX',
-          unreadCount > 0
-            ? React.createElement(
-                'span',
-                {
-                  className:
-                    'ml-2 inline-block bg-red-500 text-white text-xs rounded-full px-2'
-                },
-                unreadCount
-              )
-            : null
-        ),
-        React.createElement(
-          'span',
-          { className: 'text-sm text-gray-300' },
-          new Date().toLocaleDateString('ja-JP')
-        )
-      ),
+      React.createElement(EcoHeader, { unreadCount }),
       // 通知一覧
       React.createElement(
         'div',

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -11,6 +11,8 @@
   <!-- React ライブラリ読み込み -->
   <script src="libs/react.production.min.js"></script>
   <script src="libs/react-dom.production.min.js"></script>
+  <!-- ヘッダーコンポーネント -->
+  <script src="components/EcoHeader.js"></script>
   <!-- React コンポーネント -->
   <script defer src="ecobox.js"></script>
 </head>


### PR DESCRIPTION
## 概要
- ECOBOX のヘッダーを `EcoHeader` コンポーネントとして分離
- `notifications.html` で新しいコンポーネントを読み込み
- `ecobox.js` から `EcoHeader` を利用するよう更新

## 使い方
`public/notifications.html` をブラウザで開くと、新しいデザインのヘッダーが表示されます。未読件数は通知の状態に合わせて動的に変化します。

------
https://chatgpt.com/codex/tasks/task_e_685b4e68364c832c8eeb899ab5254f46