### PR TITLE
通知画面のホバー・アニメーション追加

### DIFF
--- a/public/ecobox.css
+++ b/public/ecobox.css
@@ -2,3 +2,26 @@
 body {
   font-family: 'Noto Sans JP', sans-serif;
 }
+/* 通知項目のホバー効果 */
+.notification-item {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.notification-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* 詳細パネルが右からスライドインするアニメーション */
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+.detail-panel {
+  animation: slideIn 0.3s ease-out;
+}

--- a/public/ecobox.js
+++ b/public/ecobox.js
@@ -81,7 +81,7 @@
               {
                 key: n.id,
                 className:
-                  'notification-item bg-gradient-to-r from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600 cursor-pointer',
+                  'notification-item bg-gradient-to-r from-slate-800 to-slate-700 rounded-xl p-4 border-2 border-cyan-400 cursor-pointer',
                 onClick: () => openDetail(n)
               },
               React.createElement(
@@ -136,7 +136,7 @@
               'div',
               {
                 className:
-                  'w-72 bg-gradient-to-b from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600'
+                  'detail-panel w-72 bg-gradient-to-b from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600'
               },
               React.createElement(
                 'div',


### PR DESCRIPTION
## 変更点
- 通知カードにホバー時の浮き出し効果を追加
- 通知カードの枠線をECOBOXと同系色（シアン）に変更
- 詳細パネル表示時にスライドインするアニメーションを実装
- 上記のためのCSSを `ecobox.css` に追記

## 使い方
`public/notifications.html` をブラウザで開くと通知一覧が表示されます。通知をクリックすると右側に詳細パネルがアニメーション付きで現れます。

## テスト結果
`npm test` を実行しましたが、`jest` が見つからずテストは実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_685b546a6278832cabc2ea3ff706ca4d