### PR TITLE
通知画面の閉じるアニメーションと拡大機能

### DIFF
--- a/public/ecobox.css
+++ b/public/ecobox.css
@@ -2,3 +2,59 @@
 body {
   font-family: 'Noto Sans JP', sans-serif;
 }
+/* 通知項目のホバー効果 */
+.notification-item {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.notification-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* 詳細パネルが右からスライドインするアニメーション */
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+.detail-panel {
+  /* パネルの拡大時にスムーズに幅が変わるよう設定 */
+  transition: width 0.3s ease;
+}
+
+/* 開くときのアニメーション */
+.detail-panel.slide-in {
+  animation: slideIn 0.3s ease-out;
+}
+
+/* 閉じるときのアニメーション */
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+.detail-panel.slide-out {
+  animation: slideOut 0.3s ease-in forwards;
+}
+
+/* 拡大表示時のスタイル */
+.detail-panel.expanded {
+  width: 100%;
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  max-width: 600px;
+  height: 90vh;
+  overflow-y: auto;
+  z-index: 50;
+}

--- a/public/ecobox.js
+++ b/public/ecobox.js
@@ -33,6 +33,10 @@
 
     // 選択された通知
     const [selected, setSelected] = useState(null);
+    // 閉じるアニメーション中かどうか
+    const [closing, setClosing] = useState(false);
+    // 拡大表示フラグ
+    const [expanded, setExpanded] = useState(false);
 
     // 既読にする処理
     const markAsRead = (id) => {
@@ -44,7 +48,21 @@
     // 通知をクリックしたとき
     const openDetail = (n) => {
       setSelected(n);
+      setClosing(false);
+      setExpanded(false);
       markAsRead(n.id);
+    };
+
+    // 詳細パネルを閉じるときの処理
+    const closeDetail = () => {
+      // アニメーションを開始
+      setClosing(true);
+      // アニメーション終了後にパネルを非表示に
+      setTimeout(() => {
+        setSelected(null);
+        setClosing(false);
+        setExpanded(false);
+      }, 300);
     };
 
     // 通知タイプごとの色
@@ -81,7 +99,7 @@
               {
                 key: n.id,
                 className:
-                  'notification-item bg-gradient-to-r from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600 cursor-pointer',
+                  'notification-item bg-gradient-to-r from-slate-800 to-slate-700 rounded-xl p-4 border-2 border-cyan-400 cursor-pointer',
                 onClick: () => openDetail(n)
               },
               React.createElement(
@@ -136,7 +154,10 @@
               'div',
               {
                 className:
-                  'w-72 bg-gradient-to-b from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600'
+                  'detail-panel ' +
+                  (closing ? 'slide-out ' : 'slide-in ') +
+                  (expanded ? 'expanded ' : 'w-72 ') +
+                  'bg-gradient-to-b from-slate-800 to-slate-700 rounded-xl p-4 border border-slate-600'
               },
               React.createElement(
                 'div',
@@ -147,12 +168,24 @@
                   '詳細情報'
                 ),
                 React.createElement(
-                  'button',
-                  {
-                    className: 'text-slate-400',
-                    onClick: () => setSelected(null)
-                  },
-                  '✕'
+                  'div',
+                  { className: 'space-x-2' },
+                  React.createElement(
+                    'button',
+                    {
+                      className: 'text-slate-400',
+                      onClick: () => setExpanded(!expanded)
+                    },
+                    expanded ? '縮小' : '拡大'
+                  ),
+                  React.createElement(
+                    'button',
+                    {
+                      className: 'text-slate-400',
+                      onClick: closeDetail
+                    },
+                    '✕'
+                  )
                 )
               ),
               React.createElement(


### PR DESCRIPTION
## 変更点
- 詳細パネル閉鎖時のスライドアウトアニメーション追加
- 拡大ボタンでパネルを画面いっぱいに表示できるように実装
- 上記に伴う `ecobox.css` と `ecobox.js` の更新

## 使い方
`public/notifications.html` をブラウザで開き、通知をクリックすると詳細パネルが表示されます。拡大ボタンで最大表示、✕ボタンでスライドして閉じます。

## テスト結果
`npm test` を実行し、全6件のテストが成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_685b546a6278832cabc2ea3ff706ca4d