### PR TITLE
ゲーム画面にGameMapを追加

### DIFF
--- a/public/components/GameMap.js
+++ b/public/components/GameMap.js
@@ -1,0 +1,54 @@
+(function () {
+  // React から useState と useEffect を取得
+  const { useState, useEffect } = React;
+
+  // -----------------------------
+  // GameMap コンポーネント
+  // 矢印キーで移動できるシンプルなマップ表示
+  // -----------------------------
+  function GameMap() {
+    // プレイヤーの位置を状態として保持 (初期位置は中心付近)
+    const [pos, setPos] = useState({ x: 50, y: 50 });
+
+    // キーボードイベントの登録
+    useEffect(() => {
+      const step = 5; // 移動量
+      const handleKey = e => {
+        setPos(p => {
+          let x = p.x;
+          let y = p.y;
+          if (e.key === 'ArrowUp') y = Math.max(0, y - step);
+          if (e.key === 'ArrowDown') y = Math.min(100, y + step);
+          if (e.key === 'ArrowLeft') x = Math.max(0, x - step);
+          if (e.key === 'ArrowRight') x = Math.min(100, x + step);
+          return { x, y };
+        });
+      };
+      window.addEventListener('keydown', handleKey);
+      // クリーンアップでイベント解除
+      return () => window.removeEventListener('keydown', handleKey);
+    }, []);
+
+    // プレイヤー位置を style で指定
+    const style = {
+      left: pos.x + '%',
+      top: pos.y + '%',
+      transform: 'translate(-50%, -50%)'
+    };
+
+    return React.createElement(
+      'div',
+      { className: 'game-map' },
+      React.createElement('div', { className: 'player', style })
+    );
+  }
+
+  // Node.js 環境へのエクスポート
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { GameMap };
+  }
+  // ブラウザ環境でのグローバル登録
+  if (typeof window !== 'undefined') {
+    window.GameMap = GameMap;
+  }
+})();

--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -1,13 +1,15 @@
 // GameScreen コンポーネント
 // ゲーム画面全体を管理するメインコンポーネント
 (function () {
-  let Sparkline, IndicatorDetailModal;
+  let Sparkline, IndicatorDetailModal, GameMap;
   if (typeof require !== 'undefined') {
     ({ Sparkline } = require('./Sparkline.js'));
     ({ IndicatorDetailModal } = require('./IndicatorDetailModal.js'));
+    ({ GameMap } = require('./GameMap.js'));
   } else if (typeof window !== 'undefined') {
     Sparkline = window.Sparkline;
     IndicatorDetailModal = window.IndicatorDetailModal;
+    GameMap = window.GameMap;
   }
 
   const { useState, useEffect, useRef } = React;
@@ -415,6 +417,8 @@
         )
       )
     ),
+    // ヘッダーの下にゲームマップを配置
+    React.createElement(GameMap, null),
     activeIndicator
       ? React.createElement(IndicatorDetailModal, {
           title: indicatorInfo[activeIndicator].label,

--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -127,3 +127,25 @@ body {
   color: #f36510;
 }
 
+
+/* ------------------------------
+   ゲームマップ表示用のスタイル
+   ------------------------------ */
+.game-map {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  margin-top: 1rem;
+  background: #e2e8f0; /* 薄いグレー */
+  border: 1px solid #94a3b8;
+  overflow: hidden;
+  z-index: 0; /* 他要素より下に表示 */
+}
+
+.player {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  background: #f87171; /* 赤系の色 */
+  border-radius: 4px;
+}

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -20,6 +20,8 @@
   <script defer src="components/Sparkline.js"></script>
   <script defer src="components/GameImpactList.js"></script>
   <script defer src="components/IndicatorDetailModal.js"></script>
+  <!-- プレイヤー位置を表示するマップ -->
+  <script defer src="components/GameMap.js"></script>
   <script defer src="components/GameScreen.js"></script>
   <!-- React版スクリプト読み込み -->
   <script defer src="game_screen_react.js"></script>

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -6,17 +6,19 @@
   const { useState, useEffect, useRef } = React;
 
   // コンポーネントを読み込み（ブラウザ環境ではグローバル変数から取得）
-  let Sparkline, IndicatorDetailModal, GameImpactList, GameScreen;
+  let Sparkline, IndicatorDetailModal, GameImpactList, GameScreen, GameMap;
   if (typeof require !== 'undefined') {
     ({ Sparkline } = require('./components/Sparkline.js'));
     ({ IndicatorDetailModal } = require('./components/IndicatorDetailModal.js'));
     ({ GameImpactList } = require('./components/GameImpactList.js'));
     ({ GameScreen } = require('./components/GameScreen.js'));
+    ({ GameMap } = require('./components/GameMap.js'));
   } else if (typeof window !== 'undefined') {
     Sparkline = window.Sparkline;
     IndicatorDetailModal = window.IndicatorDetailModal;
     GameImpactList = window.GameImpactList;
     GameScreen = window.GameScreen;
+    GameMap = window.GameMap;
   }
 
 

--- a/tests/game_map.test.js
+++ b/tests/game_map.test.js
@@ -1,0 +1,20 @@
+const React = require('react');
+const ReactDOM = require('react-dom/client');
+const { act } = require('react');
+
+describe('GameMap component', () => {
+  test('プレイヤー要素が表示される', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    global.React = React;
+    global.ReactDOM = ReactDOM;
+    const { GameMap } = require('../public/components/GameMap.js');
+
+    const container = document.createElement('div');
+    act(() => {
+      ReactDOM.createRoot(container).render(React.createElement(GameMap));
+    });
+
+    const player = container.querySelector('.player');
+    expect(player).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
- プレイヤー位置を表示する `GameMap` コンポーネントを新規作成
- `GameScreen` に `GameMap` を読み込み、ヘッダーの下に表示
- マップとプレイヤーのスタイルを `game_screen.css` に追加
- 画面HTMLとスクリプトで `GameMap` を読み込むよう更新
- `GameMap` の簡単なテストを追加

## 使い方
ゲーム画面（`game_screen_react.html`）を開き、矢印キーで赤い四角のプレイヤーを移動できます。

## テスト
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5e8b8360832cacbcb43b03454f23