### PR TITLE
ZIP解凍手順の分割

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,15 @@ npm test     # Jest でテストを実行
 ## 🌆 都市マップ素材
 
 ゲーム内マップで利用する画像パーツは Kenney 氏の素材を使用します。
-リポジトリには zip 形式で格納されているため、以下のコマンドで展開してください。
+リポジトリには ZIP 形式で格納されています。サイズが大きいため、5 段階に分けて解凍するスクリプトを用意しています。
+
+まずは以下のコマンドでステップ 1 を実行し、ライセンスファイルのみを展開します。
 
 ```bash
-unzip "public/images/kenney_city-kit-commercial_20 (1).zip" -d public/images/city-kit
-unzip public/images/kenney_roguelike-modern-city.zip -d public/images/roguelike
+bash scripts/unpack_step1.sh
 ```
+
+残りのステップは順次追加予定です。
 
 展開後、`public/tileManifest.js` で各画像を参照できるようになります。
 

--- a/public/images/city-kit/License.txt
+++ b/public/images/city-kit/License.txt
@@ -1,0 +1,28 @@
+	
+
+	City Kit Commercial (2.0)
+
+	Created/distributed by Kenney (www.kenney.nl)
+	Creation date: 17-05-2025 13:29
+	
+			------------------------------
+
+	License: (Creative Commons Zero, CC0)
+	http://creativecommons.org/publicdomain/zero/1.0/
+
+	You can use this content for personal, educational, and commercial purposes.
+
+	Support by crediting 'Kenney' or 'www.kenney.nl' (this is not a requirement)
+
+			------------------------------
+
+	• Website : www.kenney.nl
+	• Donate  : www.kenney.nl/donate
+
+	• Patreon : patreon.com/kenney
+	
+	Follow on social media for updates:
+
+	• Twitter:	 twitter.com/KenneyNL
+	• BlueSky:	 kenney.bsky.social
+	• Instagram: instagram.com/kenney_nl

--- a/public/images/roguelike/License.txt
+++ b/public/images/roguelike/License.txt
@@ -1,0 +1,23 @@
+	
+
+	Roguelike Modern City (2.0)
+
+	Created/distributed by Kenney (www.kenney.nl)
+	Creation date: 29-10-2022
+
+			------------------------------
+
+	License: (Creative Commons Zero, CC0)
+	http://creativecommons.org/publicdomain/zero/1.0/
+
+	This content is free to use in personal, educational and commercial projects.
+
+	Support us by crediting Kenney or www.kenney.nl (this is not mandatory)
+
+			------------------------------
+
+	Donate:   http://support.kenney.nl
+	Patreon:  http://patreon.com/kenney/
+
+	Follow on Twitter for updates:
+	http://twitter.com/KenneyNL

--- a/scripts/unpack_step1.sh
+++ b/scripts/unpack_step1.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# step1: ライセンスファイルのみを展開するスクリプト
+set -e
+
+# city-kit のライセンス展開
+unzip -o "public/images/kenney_city-kit-commercial_20 (1).zip" License.txt -d public/images/city-kit
+
+# roguelike のライセンス展開
+unzip -o public/images/kenney_roguelike-modern-city.zip License.txt -d public/images/roguelike
+
+echo "step1: License.txt を展開しました。"


### PR DESCRIPTION
## 概要
大量のアセット展開を一旦取り消し、ZIP ファイルのみを再配置しました。
また、ライセンスファイルだけを展開する `unpack_step1.sh` を追加し、README の手順を更新しました。

## 使い方
`bash scripts/unpack_step1.sh` を実行すると、両アセットの `License.txt` のみが展開されます。残りのファイルは今後のステップで展開予定です。

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b94d819dc832c939969935b74539c