### PR TITLE
都市マップ素材の解凍スクリプト追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,45 @@ npm test     # Jest でテストを実行
 bash scripts/unpack_step1.sh
 ```
 
-残りのステップは順次追加予定です。
+続けてステップ 2 〜 5 を順に実行してください。
+
+#### ステップ 2：主要画像の展開
+```bash
+bash scripts/unpack_step2.sh
+```
+`Tilemap/` や `Tiles/`、city-kit の基本 PNG が `public/images/` 以下に展開されます。
+
+#### ステップ 3：オプション素材の展開
+```bash
+bash scripts/unpack_step3.sh
+```
+残りの 3D モデルやテキストファイルが展開されます。
+
+#### ステップ 4：不要ファイルの削除
+```bash
+bash scripts/unpack_step4.sh
+```
+`Sample.png` や `Preview*.png`、`.url` ファイルを削除して整理します。
+
+#### ステップ 5：ZIP の削除（任意）
+```bash
+bash scripts/unpack_step5.sh
+```
+アーカイブを削除してディスク容量を節約します。
 
 展開後、`public/tileManifest.js` で各画像を参照できるようになります。
+
+主なディレクトリ構成例:
+
+```
+public/images/
+├─ city-kit/
+│  ├─ Previews/
+│  └─ Models/...
+├─ roguelike/
+│  ├─ Tilemap/
+│  └─ Tiles/
+```
 
 ### city-kit（アイソメトリック）
 

--- a/scripts/unpack_step2.sh
+++ b/scripts/unpack_step2.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# step2: 必要な画像のみを解凍するスクリプト
+set -e
+
+# roguelike の主要画像(Tiles と Tilemap)を展開
+unzip -o public/images/kenney_roguelike-modern-city.zip "Tilemap/*" "Tiles/*" -d public/images/roguelike
+
+# city-kit の主な PNG ファイルを展開
+unzip -o "public/images/kenney_city-kit-commercial_20 (1).zip" "Previews/*" "Preview*.png" "Models/Textures/*" -d public/images/city-kit
+
+echo "step2: 必要な画像を展開しました。"

--- a/scripts/unpack_step3.sh
+++ b/scripts/unpack_step3.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# step3: 残りのオプション素材を解凍するスクリプト
+set -e
+
+# roguelike の残りファイルを展開（ライセンスと主要画像を除く）
+unzip -o public/images/kenney_roguelike-modern-city.zip -x "Tilemap/*" "Tiles/*" "License.txt" -d public/images/roguelike
+
+# city-kit の残りファイルを展開（主要PNGとライセンスを除く）
+unzip -o "public/images/kenney_city-kit-commercial_20 (1).zip" -x "Previews/*" "Preview*.png" "Models/Textures/*" "License.txt" -d public/images/city-kit
+
+echo "step3: オプション素材を展開しました。"

--- a/scripts/unpack_step4.sh
+++ b/scripts/unpack_step4.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# step4: サンプル画像や .url ファイルを削除するスクリプト
+set -e
+
+# Sample.png や Preview.png 系を削除
+find public/images -type f -name 'Sample.png' -delete
+find public/images -type f -name 'Preview*.png' -delete
+
+# URLショートカットを削除
+find public/images -type f -name '*.url' -delete
+
+echo "step4: 余分なファイルを削除しました。"

--- a/scripts/unpack_step5.sh
+++ b/scripts/unpack_step5.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# step5: ZIP アーカイブを削除するスクリプト（任意実行）
+set -e
+
+rm -f "public/images/kenney_city-kit-commercial_20 (1).zip"
+rm -f public/images/kenney_roguelike-modern-city.zip
+
+echo "step5: ZIP ファイルを削除しました。"


### PR DESCRIPTION
## 変更内容
- 画像素材展開用のシェルスクリプトを4つ追加
  - `unpack_step2.sh`: 主要画像を展開
  - `unpack_step3.sh`: 残りのオプション素材を展開
  - `unpack_step4.sh`: サンプル画像や `.url` を削除
  - `unpack_step5.sh`: ZIP アーカイブを削除
- README の都市マップ素材手順を更新
  - 各ステップの実行方法と処理内容を追記
  - 最終的なディレクトリ構成例を追加

## テスト結果
- `npm install` は成功
- `npm test` は jsdom 環境不足により失敗


------
https://chatgpt.com/codex/tasks/task_e_685c8d1f4000832ca6ffcb4a400c9eb1