### PR TITLE
画像パスの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ bash scripts/unpack_step1.sh
 ```bash
 bash scripts/unpack_step2.sh
 ```
-`Tilemap/` や `Tiles/`、city-kit の基本 PNG が `public/images/` 以下に展開されます。
+`Tilemap/` や `Tiles/`、city-kit の基本 PNG が `images/` 以下に展開されます。
 
 #### ステップ 3：オプション素材の展開
 ```bash
@@ -170,7 +170,7 @@ bash scripts/unpack_step5.sh
 主なディレクトリ構成例:
 
 ```
-public/images/
+images/
 ├─ city-kit/
 │  ├─ Previews/
 │  └─ Models/...

--- a/public/tileManifest.js
+++ b/public/tileManifest.js
@@ -1,19 +1,19 @@
 // tileManifest.js
 // 都市マップ用タイル画像のパスをまとめたマニフェストです
-// 画像ファイルは /public/images 以下に展開してください
+// 画像ファイルは images フォルダ以下に展開してください
 
 export const tileManifest = {
   // Roguelike素材
-  asphalt: "/public/images/roguelike/tile_0001.png",
-  road_horizontal: "/public/images/roguelike/tile_0012.png",
-  building_wall: "/public/images/roguelike/tile_0025.png",
-  grass: "/public/images/roguelike/tile_0033.png",
-  pedestrian_crossing: "/public/images/roguelike/tile_0040.png",
+  asphalt: "/images/roguelike/tile_0001.png",
+  road_horizontal: "/images/roguelike/tile_0012.png",
+  building_wall: "/images/roguelike/tile_0025.png",
+  grass: "/images/roguelike/tile_0033.png",
+  pedestrian_crossing: "/images/roguelike/tile_0040.png",
 
   // City-kit素材（アイソメ）
-  building_bg: "/public/images/city-kit/Building_Background.png",
-  road_straight: "/public/images/city-kit/Road_Straight.png",
-  tree: "/public/images/city-kit/Tree_01.png",
-  car_blue: "/public/images/city-kit/Car_Blue.png",
-  character_01: "/public/images/city-kit/People_01.png",
+  building_bg: "/images/city-kit/Building_Background.png",
+  road_straight: "/images/city-kit/Road_Straight.png",
+  tree: "/images/city-kit/Tree_01.png",
+  car_blue: "/images/city-kit/Car_Blue.png",
+  character_01: "/images/city-kit/People_01.png",
 };


### PR DESCRIPTION
## 概要
- `tileManifest.js` のパスから `public/` を削除
- README の対応箇所を修正
- ローカルサーバーで画像が読み込めることを確認

## テスト結果
- `npm test` を実行しましたが、Jest の環境設定不足によりテストは失敗しました

------
https://chatgpt.com/codex/tasks/task_e_685c8ed22370832ca954d032b4bb0566