### PR TITLE
マップCanvas表示機能の追加

### DIFF
--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -22,10 +22,14 @@
   <script defer src="components/GameImpactList.js"></script>
   <script defer src="components/IndicatorDetailModal.js"></script>
   <script defer src="components/GameScreen.js"></script>
+  <!-- マップ表示用スクリプト -->
+  <script defer src="tileManifest.js"></script>
+  <script defer src="map_canvas.js"></script>
   <!-- React版スクリプト読み込み -->
   <script defer src="game_screen_react.js"></script>
 </head>
 <body class="bg-gray-100 select-none font-[Orbitron]">
+  <canvas id="mapCanvas" class="mx-auto my-2 border"></canvas>
   <div id="root"></div>
 </body>
 </html>

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -69,6 +69,10 @@
     ReactDOM.createRoot(document.getElementById('root')).render(
       React.createElement(GameScreen)
     );
+    // マップCanvasの初期化も行う
+    if (typeof initMapCanvas === 'function') {
+      initMapCanvas();
+    }
   });
 
   // ブラウザからも参照できるようグローバルに登録

--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -1,0 +1,65 @@
+(function () {
+  const TILE_SIZE = 32;
+  const mapData = [
+    ['grass','grass','grass','grass','grass','grass','grass','grass','grass','grass'],
+    ['grass','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','grass'],
+    ['grass','road_horizontal','building_wall','building_wall','building_wall','building_wall','building_wall','building_wall','road_horizontal','grass'],
+    ['grass','road_horizontal','building_bg','building_bg','building_bg','building_bg','building_bg','building_bg','road_horizontal','grass'],
+    ['grass','road_horizontal','building_bg','tree','tree','tree','tree','building_bg','road_horizontal','grass'],
+    ['grass','road_horizontal','building_bg','tree','character_01','car_blue','tree','building_bg','road_horizontal','grass'],
+    ['grass','road_horizontal','building_bg','tree','tree','tree','tree','building_bg','road_horizontal','grass'],
+    ['grass','road_horizontal','building_bg','building_bg','building_bg','building_bg','building_bg','building_bg','road_horizontal','grass'],
+    ['grass','road_horizontal','road_horizontal','road_horizontal','pedestrian_crossing','road_horizontal','road_horizontal','road_horizontal','road_horizontal','grass'],
+    ['grass','grass','grass','grass','grass','grass','grass','grass','grass','grass'],
+  ];
+
+  function loadImages(manifest, callback) {
+    const keys = Object.keys(manifest);
+    const images = {};
+    let loaded = 0;
+    keys.forEach(key => {
+      const img = new Image();
+      img.src = manifest[key];
+      img.onload = () => {
+        loaded++;
+        if (loaded === keys.length) {
+          callback(images);
+        }
+      };
+      images[key] = img;
+    });
+  }
+
+  function drawMap(canvas, ctx, images) {
+    for (let y = 0; y < mapData.length; y++) {
+      for (let x = 0; x < mapData[y].length; x++) {
+        const tile = mapData[y][x];
+        const img = images[tile];
+        if (img) {
+          ctx.drawImage(img, x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        }
+      }
+    }
+  }
+
+  function initMapCanvas() {
+    const canvas = document.getElementById('mapCanvas');
+    if (!canvas || typeof tileManifest === 'undefined') {
+      return;
+    }
+    const ctx = canvas.getContext('2d');
+    canvas.width = mapData[0].length * TILE_SIZE;
+    canvas.height = mapData.length * TILE_SIZE;
+    const usedKeys = [...new Set(mapData.flat())];
+    const manifest = {};
+    usedKeys.forEach(k => { if (tileManifest[k]) manifest[k] = tileManifest[k]; });
+    loadImages(manifest, (images) => { drawMap(canvas, ctx, images); });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initMapCanvas };
+  }
+  if (typeof window !== 'undefined') {
+    window.initMapCanvas = initMapCanvas;
+  }
+})();

--- a/public/tileManifest.js
+++ b/public/tileManifest.js
@@ -2,7 +2,7 @@
 // 都市マップ用タイル画像のパスをまとめたマニフェストです
 // 画像ファイルは images フォルダ以下に展開してください
 
-export const tileManifest = {
+const tileManifest = {
   // Roguelike素材
   asphalt: "/images/roguelike/tile_0001.png",
   road_horizontal: "/images/roguelike/tile_0012.png",
@@ -17,3 +17,13 @@ export const tileManifest = {
   car_blue: "/images/city-kit/Car_Blue.png",
   character_01: "/images/city-kit/People_01.png",
 };
+
+// CommonJS エクスポート
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { tileManifest };
+}
+
+// ブラウザ環境ではグローバル変数として使えるようにする
+if (typeof window !== 'undefined') {
+  window.tileManifest = tileManifest;
+}


### PR DESCRIPTION
## 変更内容
- `tileManifest.js` をCommonJSにも対応し、ブラウザでグローバル変数化
- 新規 `map_canvas.js` を作成し、タイルマップをCanvasへ描画する処理を実装
- `game_screen_react.js` からCanvas初期化を呼び出すよう修正
- `game_screen_react.html` に `<canvas id="mapCanvas">` と関連スクリプトを追加

## 動作確認
- `npm test` を実行しましたが、環境の都合で `document is not defined` エラーが発生しました


------
https://chatgpt.com/codex/tasks/task_e_685c984ba69c832c9b54c561ce047478