### PR TITLE
画像展開スクリプトのパス調整

### DIFF
--- a/scripts/unpack_step2.sh
+++ b/scripts/unpack_step2.sh
@@ -2,10 +2,10 @@
 # step2: 必要な画像のみを解凍するスクリプト
 set -e
 
-# roguelike の主要画像(Tiles と Tilemap)を展開
-unzip -o public/images/kenney_roguelike-modern-city.zip "Tilemap/*" "Tiles/*" -d public/images/roguelike
+# roguelike の主要画像(Tiles ディレクトリの PNG)をパス情報を除いて展開
+unzip -o -j public/images/kenney_roguelike-modern-city.zip "Tiles/*.png" -d public/images/roguelike
 
-# city-kit の主な PNG ファイルを展開
-unzip -o public/images/kenney_city-kit-commercial_20.zip "Previews/*" "Preview*.png" "Models/Textures/*" -d public/images/city-kit
+# city-kit の主な PNG ファイルを同様に展開（階層を無視してフラットに配置）
+unzip -o -j public/images/kenney_city-kit-commercial_20.zip "Previews/*.png" "Preview*.png" "Models/Textures/*.png" -d public/images/city-kit
 
 echo "step2: 必要な画像を展開しました。"

--- a/scripts/unpack_step3.sh
+++ b/scripts/unpack_step3.sh
@@ -3,9 +3,9 @@
 set -e
 
 # roguelike の残りファイルを展開（ライセンスと主要画像を除く）
-unzip -o public/images/kenney_roguelike-modern-city.zip -x "Tilemap/*" "Tiles/*" "License.txt" -d public/images/roguelike
+unzip -o -j public/images/kenney_roguelike-modern-city.zip -x "Tilemap/*" "Tiles/*" "License.txt" -d public/images/roguelike
 
 # city-kit の残りファイルを展開（主要PNGとライセンスを除く）
-unzip -o public/images/kenney_city-kit-commercial_20.zip -x "Previews/*" "Preview*.png" "Models/Textures/*" "License.txt" -d public/images/city-kit
+unzip -o -j public/images/kenney_city-kit-commercial_20.zip -x "Previews/*" "Preview*.png" "Models/Textures/*" "License.txt" -d public/images/city-kit
 
 echo "step3: オプション素材を展開しました。"


### PR DESCRIPTION
## 概要
`unpack_step2.sh` と `unpack_step3.sh` で展開される画像の配置先パスが `tileManifest.js` と合うように、解凍時にディレクトリ階層を無視する `-j` オプションを追加しました。
これにより、`public/images/roguelike` や `public/images/city-kit` 直下へ PNG が展開されます。

## 動作確認
- `npm install`
- `npm test`
  - 6件のテストスイートがすべて成功することを確認

## 使い方
`scripts/unpack_step1.sh` から `unpack_step5.sh` を順に実行すると、画像が所定の場所へ展開されます。

------
https://chatgpt.com/codex/tasks/task_e_685ca0d8aa40832cad0c0b9a4f8e5791