### PR TITLE
マップキャンバスの追加

### DIFF
--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -132,6 +132,7 @@ body {
 canvas#mapCanvas {
   width: 100%;
   height: 100%;
+  flex-grow: 1;
 }
 
 

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="globals.css">
   <link rel="stylesheet" href="game_screen.css">
 </head>
-<body class="h-screen overflow-hidden font-[Orbitron]">
+<body class="h-screen overflow-hidden font-[Orbitron] flex flex-col">
 
   <!-- ヘッダー: 収入と評価を表示 -->
   <header class="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900/90 text-white flex justify-between items-center px-4 py-2">
@@ -36,6 +36,8 @@
       </span>
     </div>
   </header>
+  <!-- マップ表示用キャンバス -->
+  <canvas id="mapCanvas" class="flex-grow w-full"></canvas>
   <!-- ドロワー用のオーバーレイ -->
   <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->
@@ -81,6 +83,9 @@
       <p id="detailText" class="text-sm whitespace-pre-line"></p>
     </div>
   </div>
+  <!-- マップ描画に必要なスクリプト -->
+  <script src="tileManifest.js"></script>
+  <script src="map_canvas.js"></script>
   <!-- ゲーム用スクリプトを読み込み -->
   <script src="game_screen.js"></script>
 

--- a/public/game_screen.js
+++ b/public/game_screen.js
@@ -109,4 +109,9 @@ window.addEventListener('DOMContentLoaded', () => {
       modal.classList.add('hidden');
     });
   });
+
+  // すべての初期設定が完了したらマップを描画開始
+  if (typeof initMapCanvas === 'function') {
+    initMapCanvas();
+  }
 }, { capture: true });


### PR DESCRIPTION
## 概要
- game_screen.html に `<canvas id="mapCanvas">` を配置
- tileManifest.js と map_canvas.js を game_screen.js より前に読み込み
- game_screen.js から `initMapCanvas()` を呼び出して描画開始
- マップキャンバスが残りの高さを使うよう CSS を調整

## 使い方
ゲーム画面を開くとヘッダーの下にマップが表示されます。矢印キーでキャラクターを移動できます。

------
https://chatgpt.com/codex/tasks/task_e_685cbcd99ea0832c8d7d32c514073238