### PR TITLE
ゲーム画面のマップ背景を黒に変更

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -427,7 +427,8 @@
     React.createElement('canvas', {
       id: 'mapCanvas',
       // 高さ可変にするためflex-growを付与し幅いっぱいに広げる
-      className: 'flex-grow w-full border'
+      // 背景色を黒にしてマップを見やすくする
+      className: 'flex-grow w-full border bg-black'
     }),
     activeIndicator
       ? React.createElement(IndicatorDetailModal, {

--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -133,6 +133,8 @@ canvas#mapCanvas {
   width: 100%;
   height: 100%;
   flex-grow: 1;
+  /* 黒ベースの背景色を指定してマップを際立たせる */
+  background-color: #000;
 }
 
 

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -37,7 +37,7 @@
     </div>
   </header>
   <!-- マップ表示用キャンバス -->
-  <canvas id="mapCanvas" class="flex-grow w-full"></canvas>
+  <canvas id="mapCanvas" class="flex-grow w-full bg-black"></canvas>
   <!-- ドロワー用のオーバーレイ -->
   <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->

--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -86,6 +86,9 @@
   function drawMap(canvas, ctx, images) {
     // いったん画面をクリア
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // キャンバス全体を黒で塗りつぶして背景色を固定
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     // カメラの位置に合わせて原点を移動
     ctx.save();


### PR DESCRIPTION
## 変更点
- `map_canvas.js` で描画前に黒塗りを追加
- `game_screen.css` の `#mapCanvas` に背景色指定を追加
- `game_screen.html` でキャンバスに `bg-black` クラスを付与
- React 版 `GameScreen.js` でも同様に `bg-black` を付与

## テスト結果
- `npm test` が全て成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_685cbe2418c0832c9b9ba47ddd3ec307